### PR TITLE
Gateway fixes

### DIFF
--- a/src/app/gateway/assets/locale/locale.constant-en_US.json
+++ b/src/app/gateway/assets/locale/locale.constant-en_US.json
@@ -122,7 +122,6 @@
     "enable-remote-logging": "Enable remote logging",
     "ellipsis-chips-text": "+ {{count}} more",
     "launch-gateway": "Launch gateway",
-    "launch-command": "Launch command",
     "launch-docker-compose": "Start the gateway using the following command in the terminal from folder with docker-compose.yml file",
     "logs-configuration": "Logs configuration",
     "create-new-gateway": "Create a new gateway",

--- a/src/app/gateway/shared/models/gateway.models.ts
+++ b/src/app/gateway/shared/models/gateway.models.ts
@@ -17,7 +17,7 @@
 import { AbstractControl, ValidationErrors } from '@angular/forms';
 import {
   ConnectorBaseConfig_v3_5_2,
-  ConnectorBaseConfig_v3_5_3,
+  ConnectorBaseConfig_v3_6,
   ConnectorLegacyConfig
 } from '../../states/gateway-connectors/models/public-api';
 import { ConfigurationModes, ReportStrategyConfig } from './report-strategy.models';
@@ -39,7 +39,7 @@ export enum GatewayLogLevel {
 }
 
 export enum GatewayVersion {
-  Current = '3.5.4',
+  Current = '3.6',
   v3_5_2 = '3.5.2',
   Legacy = 'legacy'
 }
@@ -82,7 +82,7 @@ export const GatewayConnectorDefaultTypesTranslatesMap = new Map<ConnectorType, 
   [ConnectorType.CUSTOM, 'CUSTOM']
 ]);
 
-export type ConnectorBaseConfig = ConnectorBaseConfig_v3_5_3 | ConnectorBaseConfig_v3_5_2 | ConnectorLegacyConfig;
+export type ConnectorBaseConfig = ConnectorBaseConfig_v3_6 | ConnectorBaseConfig_v3_5_2 | ConnectorLegacyConfig;
 
 export interface GatewayConnector<BaseConfig = ConnectorBaseConfig> extends GatewayConnectorBase {
   configurationJson: BaseConfig;
@@ -106,7 +106,7 @@ export interface GatewayConnectorBase {
 export interface GatewayVersionedDefaultConfig {
   legacy: GatewayConnector<ConnectorLegacyConfig>;
   '3.5.2'?: GatewayConnector<ConnectorBaseConfig_v3_5_2>;
-  '3.5.4'?: GatewayConnector<ConnectorBaseConfig_v3_5_3>;
+  '3.6'?: GatewayConnector<ConnectorBaseConfig_v3_6>;
 }
 
 export interface Attribute {

--- a/src/app/gateway/shared/models/modbus.models.ts
+++ b/src/app/gateway/shared/models/modbus.models.ts
@@ -19,7 +19,6 @@ export enum ModbusDataType {
   BITS = 'bits',
   INT8 = '8int',
   UINT8 = '8uint',
-  FLOAT8 = '8float',
   INT16 = '16int',
   UINT16 = '16uint',
   FLOAT16 = '16float',
@@ -36,7 +35,6 @@ export const ModbusEditableDataTypes = [ModbusDataType.BYTES, ModbusDataType.BIT
 export enum ModbusObjectCountByDataType {
   '8int' = 1,
   '8uint' = 1,
-  '8float' = 1,
   '16int' = 1,
   '16uint' = 1,
   '16float' = 1,

--- a/src/app/gateway/states/gateway-connectors/abstract/socket-version-processor.abstract.ts
+++ b/src/app/gateway/states/gateway-connectors/abstract/socket-version-processor.abstract.ts
@@ -16,7 +16,7 @@
 
 import {
   SocketBasicConfig,
-  SocketBasicConfig_v3_5_3,
+  SocketBasicConfig_v3_6,
   SocketLegacyBasicConfig,
 } from '../models/public-api';
 import { GatewayConnectorVersionProcessor } from './gateway-connector-version-processor.abstract';
@@ -32,7 +32,7 @@ export class SocketVersionProcessor extends GatewayConnectorVersionProcessor<Soc
     super(gatewayVersionIn, connector);
   }
 
-  getUpgradedVersion(): GatewayConnector<SocketBasicConfig_v3_5_3> {
+  getUpgradedVersion(): GatewayConnector<SocketBasicConfig_v3_6> {
     const configurationJson = this.connector.configurationJson;
     return {
       ...this.connector,
@@ -41,7 +41,7 @@ export class SocketVersionProcessor extends GatewayConnectorVersionProcessor<Soc
         devices: configurationJson?.devices ? SocketVersionMappingUtil.mapDevicesToUpgradedVersion(configurationJson.devices) : [],
       },
       configVersion: this.gatewayVersionIn
-    } as GatewayConnector<SocketBasicConfig_v3_5_3>;
+    } as GatewayConnector<SocketBasicConfig_v3_6>;
   }
 
   getDowngradedVersion(): GatewayConnector<SocketLegacyBasicConfig> {

--- a/src/app/gateway/states/gateway-connectors/components/add-connector-dialog/add-connector-dialog.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/add-connector-dialog/add-connector-dialog.component.html
@@ -80,7 +80,7 @@
           </mat-label>
         </mat-slide-toggle>
       </div>
-      <div *ngIf="connectorForm.get('type').value === connectorType.MQTT" class="tb-form-row column-xs">
+      <div *ngIf="connectorForm.get('type').value === connectorType.MQTT && !(data.gatewayVersion | withReportStrategy : connectorType.MQTT)" class="tb-form-row column-xs">
         <mat-slide-toggle class="mat-slide" formControlName="sendDataOnlyOnChange">
           <mat-label tb-hint-tooltip-icon="{{ 'gateway.send-change-data-hint' | translate }}">
             {{ 'gateway.send-change-data' | translate }}

--- a/src/app/gateway/states/gateway-connectors/components/add-connector-dialog/add-connector-dialog.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/add-connector-dialog/add-connector-dialog.component.ts
@@ -26,7 +26,8 @@ import {
   GatewayLogLevel,
   GatewayVersion,
   noLeadTrailSpacesRegex,
-  getDefaultConfig
+  getDefaultConfig,
+  ReportStrategyVersionPipe
 } from '../../../../shared/public-api';
 import {
   AddConnectorConfigData,
@@ -47,7 +48,8 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [
     CommonModule,
-    SharedModule
+    SharedModule,
+    ReportStrategyVersionPipe
   ]
 })
 export class AddConnectorDialogComponent

--- a/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.html
@@ -28,7 +28,7 @@
                     <div tbTruncateWithTooltip class="title-container">
                       {{ keyControl.get('key').value }}
                     </div>
-                    {{ '-' }}
+                    {{ ':' }}&nbsp;
                   </ng-container>
                   <div tbTruncateWithTooltip class="title-container">{{ valueTitle(keyControl) }}</div>
                 </mat-panel-title>

--- a/src/app/gateway/states/gateway-connectors/components/modbus/modbus-data-keys-panel/modbus-data-keys-panel.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/modbus/modbus-data-keys-panel/modbus-data-keys-panel.component.html
@@ -25,7 +25,7 @@
               <mat-expansion-panel-header class="flex-wrap">
                 <mat-panel-title>
                   <div *ngIf="isMaster else tagName" class="title-container" tbTruncateWithTooltip>
-                    {{ keyControl.get('tag').value }}{{ '-' }}{{ keyControl.get('value').value }}
+                    {{ keyControl.get('tag').value }}{{ ': ' }}{{ keyControl.get('value').value }}
                   </div>
                   <ng-template #tagName>
                     <div class="tb-flex">

--- a/src/app/gateway/states/gateway-connectors/components/socket/socket-basic-config/socket-basic-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/socket/socket-basic-config/socket-basic-config.component.ts
@@ -27,7 +27,7 @@ import {
   NG_VALUE_ACCESSOR,
   Validator,
 } from '@angular/forms';
-import { SocketBasicConfig_v3_5_3, SocketConfig } from '../../../models/public-api';
+import { SocketBasicConfig_v3_6, SocketConfig } from '../../../models/public-api';
 import { SharedModule } from '@shared/public-api';
 import { CommonModule } from '@angular/common';
 import { SocketConfigComponent } from '../socket-config/socket-config.component';
@@ -62,9 +62,9 @@ import {
   styleUrls: ['./socket-basic-config.component.scss']
 })
 
-export class SocketBasicConfigComponent extends GatewayConnectorBasicConfigDirective<SocketBasicConfig_v3_5_3, SocketBasicConfig_v3_5_3> implements ControlValueAccessor, Validator, OnDestroy {
+export class SocketBasicConfigComponent extends GatewayConnectorBasicConfigDirective<SocketBasicConfig_v3_6, SocketBasicConfig_v3_6> implements ControlValueAccessor, Validator, OnDestroy {
 
-  protected getMappedValue(config: SocketBasicConfig_v3_5_3): SocketBasicConfig_v3_5_3 {
+  protected getMappedValue(config: SocketBasicConfig_v3_6): SocketBasicConfig_v3_6 {
     return config;
   }
 
@@ -75,7 +75,7 @@ export class SocketBasicConfigComponent extends GatewayConnectorBasicConfigDirec
     });
   }
 
-  protected mapConfigToFormValue(config: SocketBasicConfig_v3_5_3): SocketBasicConfig_v3_5_3 {
+  protected mapConfigToFormValue(config: SocketBasicConfig_v3_6): SocketBasicConfig_v3_6 {
     return {
       socket: config.socket ?? {} as SocketConfig,
       devices: config.devices ?? [],

--- a/src/app/gateway/states/gateway-connectors/components/socket/socket-basic-config/socket-legacy-basic-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/socket/socket-basic-config/socket-legacy-basic-config.component.ts
@@ -35,7 +35,7 @@ import {
   GatewayConnectorBasicConfigDirective
 } from '../../../abstract/public-api';
 import { SocketVersionMappingUtil } from '../../../utils/public-api';
-import { SocketBasicConfig_v3_5_3, SocketLegacyBasicConfig } from '../../../models/public-api';
+import { SocketBasicConfig_v3_6, SocketLegacyBasicConfig } from '../../../models/public-api';
 
 @Component({
   selector: 'tb-socket-legacy-basic-config',
@@ -63,9 +63,9 @@ import { SocketBasicConfig_v3_5_3, SocketLegacyBasicConfig } from '../../../mode
   styleUrls: ['./socket-basic-config.component.scss']
 })
 
-export class SocketLegacyBasicConfigComponent extends GatewayConnectorBasicConfigDirective<SocketBasicConfig_v3_5_3, SocketLegacyBasicConfig> implements ControlValueAccessor, Validator, OnDestroy {
+export class SocketLegacyBasicConfigComponent extends GatewayConnectorBasicConfigDirective<SocketBasicConfig_v3_6, SocketLegacyBasicConfig> implements ControlValueAccessor, Validator, OnDestroy {
 
-  protected getMappedValue(config: SocketBasicConfig_v3_5_3): SocketLegacyBasicConfig {
+  protected getMappedValue(config: SocketBasicConfig_v3_6): SocketLegacyBasicConfig {
     return SocketVersionMappingUtil.mapSocketToDowngradedVersion(config);
   }
 
@@ -76,10 +76,10 @@ export class SocketLegacyBasicConfigComponent extends GatewayConnectorBasicConfi
     });
   }
 
-  protected mapConfigToFormValue(config: SocketLegacyBasicConfig): SocketBasicConfig_v3_5_3 {
+  protected mapConfigToFormValue(config: SocketLegacyBasicConfig): SocketBasicConfig_v3_6 {
     return {
       socket: SocketVersionMappingUtil.mapSocketToUpgradedVersion(config),
-      devices: config?.devices ? SocketVersionMappingUtil.mapDevicesToUpgradedVersion(config) : [],
+      devices: config?.devices ? SocketVersionMappingUtil.mapDevicesToUpgradedVersion(config.devices) : [],
     };
   }
 }

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.html
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.html
@@ -242,6 +242,7 @@
           </mat-tab>
           <mat-tab label="{{ 'gateway.configuration' | translate }}*">
             <tb-json-object-edit
+              class="configuration-json"
               [fillHeight]="true"
               jsonRequired
               label="{{ 'gateway.configuration' | translate }}"

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.scss
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.scss
@@ -153,5 +153,13 @@
       }
     }
   }
+
+  .configuration-json {
+    .ace_tooltip {
+      @media #{constants.$mat-gt-sm} {
+        transform: translate(-250px, -120px);
+      }
+    }
+  }
 }
 

--- a/src/app/gateway/states/gateway-connectors/models/connectors.model.ts
+++ b/src/app/gateway/states/gateway-connectors/models/connectors.model.ts
@@ -40,7 +40,7 @@ import {
   DeviceAttributesUpdate,
   DeviceDataKey,
   DeviceRpcMethod,
-  SocketBasicConfig_v3_5_3,
+  SocketBasicConfig_v3_6,
   SocketEncoding,
   SocketLegacyBasicConfig
 } from './socket.models';
@@ -304,7 +304,7 @@ export type ConnectorLegacyConfig = ConnectorBaseInfo | MQTTLegacyBasicConfig | 
 
 export type ConnectorBaseConfig_v3_5_2 = ConnectorBaseInfo | MQTTBasicConfig_v3_5_2 | OPCBasicConfig_v3_5_2 | ModbusBasicConfig_v3_5_2;
 
-export type ConnectorBaseConfig_v3_5_3 = ConnectorBaseInfo | SocketBasicConfig_v3_5_3;
+export type ConnectorBaseConfig_v3_6 = ConnectorBaseInfo | SocketBasicConfig_v3_6;
 
 export interface DevicesConfigMapping {
   address: string;

--- a/src/app/gateway/states/gateway-connectors/models/socket.models.ts
+++ b/src/app/gateway/states/gateway-connectors/models/socket.models.ts
@@ -73,9 +73,9 @@ export const SocketKeysPanelTitleTranslationsMap = new Map<SocketValueKey, strin
   ]
 );
 
-export type SocketBasicConfig = SocketBasicConfig_v3_5_3 | SocketLegacyBasicConfig;
+export type SocketBasicConfig = SocketBasicConfig_v3_6 | SocketLegacyBasicConfig;
 
-export interface SocketBasicConfig_v3_5_3 {
+export interface SocketBasicConfig_v3_6 {
   socket: SocketConfig;
   devices: DevicesConfigMapping[];
 }

--- a/src/app/gateway/states/gateway-connectors/utils/gateway-connector-version-mapping.util.ts
+++ b/src/app/gateway/states/gateway-connectors/utils/gateway-connector-version-mapping.util.ts
@@ -45,10 +45,13 @@ export abstract class GatewayConnectorVersionMappingUtil {
   }
 
   static parseVersion(version: string | number): number {
-    if (isNumber(version)) {
-      return version as number;
+    if (isNumber(version)) return version as number;
+
+    if (isString(version)) {
+      const [major, minor = '0', patch = '0'] = (version as string).split('.');
+      return parseFloat(`${major}.${minor}${patch.slice(0, 1)}`);
     }
 
-    return isString(version) ? parseFloat((version as string).replace(/\./g, '').slice(0, 3)) / 100 : 0;
+    return 0;
   }
 }

--- a/src/app/gateway/states/gateway-connectors/utils/modbus-version-mapping.util.ts
+++ b/src/app/gateway/states/gateway-connectors/utils/modbus-version-mapping.util.ts
@@ -82,7 +82,7 @@ export class ModbusVersionMappingUtil {
     const values = Object.keys(slave.values).reduce((acc, valueKey) => {
       acc = {
         ...acc,
-        [valueKey]: this.mapValuesToUpgradedVersion(slave.values[valueKey][0])
+        [valueKey]: this.mapValuesToUpgradedVersion(slave.values[valueKey][0] ?? {})
       };
       return acc;
     }, {} as ModbusRegisterValues);

--- a/src/app/gateway/states/gateway-connectors/utils/socket-version-mapping.util.ts
+++ b/src/app/gateway/states/gateway-connectors/utils/socket-version-mapping.util.ts
@@ -18,7 +18,7 @@ import {
   DevicesConfigMapping,
   ExpressionType,
   LegacyDevicesConfigMapping,
-  SocketBasicConfig_v3_5_3,
+  SocketBasicConfig_v3_6,
   SocketConfig,
   SocketLegacyBasicConfig,
 } from '../models/public-api';
@@ -30,7 +30,7 @@ export class SocketVersionMappingUtil {
     return socket;
   }
 
-  static mapSocketToDowngradedVersion(config: SocketBasicConfig_v3_5_3): SocketLegacyBasicConfig {
+  static mapSocketToDowngradedVersion(config: SocketBasicConfig_v3_6): SocketLegacyBasicConfig {
     const { devices, socket } = config ?? {};
     return {
       ...socket,
@@ -38,8 +38,8 @@ export class SocketVersionMappingUtil {
     }
   }
 
-  static mapDevicesToUpgradedVersion(config: SocketLegacyBasicConfig): DevicesConfigMapping[] {
-    return config.devices?.map(device => ({
+  static mapDevicesToUpgradedVersion(devices: LegacyDevicesConfigMapping[]): DevicesConfigMapping[] {
+    return devices?.map(device => ({
       ...device,
       attributeRequests: device.attributeRequests?.map(request => ({
         ...request,

--- a/src/app/gateway/states/gateway-service-rpc/components/gateway-service-rpc-connector/gateway-service-rpc-connector.component.html
+++ b/src/app/gateway/states/gateway-service-rpc/components/gateway-service-rpc-connector/gateway-service-rpc-connector.component.html
@@ -167,7 +167,7 @@
           </mat-select>
         </mat-form-field>
         <mat-form-field class="mat-block">
-          <mat-label>{{ 'gateway.rpc.encoding' | translate }}</mat-label>
+          <mat-label>{{ 'gateway.encoding' | translate }}</mat-label>
           <input matInput formControlName="encoding" placeholder="{{socketEncodings[0]}}"/>
         </mat-form-field>
         <mat-slide-toggle class="mat-slide margin" formControlName="withResponse">


### PR DESCRIPTION
## Gateway fixes:
- changed current version to 3.6 and adjusted version mapping for it
- deleted 8float data type
![image](https://github.com/user-attachments/assets/d4967458-bc36-4df7-a451-5141d17d899e)
- deleted sendDataOnlyOnChange for MQTT new config version 
![image](https://github.com/user-attachments/assets/717c35b5-614a-46aa-992b-8ce9b49c7dab)
- changed mapping keys view 
![image](https://github.com/user-attachments/assets/18815534-82e8-4c42-a509-d26884fe355c)
- json editor wrong hint placement fix
![image](https://github.com/user-attachments/assets/a622a6f8-05f6-4900-b88f-c3c555551d01)
- socket encoding translation fix
- modbus server empty values version mapping fix 