### PR TITLE
Gateway fixes and improvements

### DIFF
--- a/src/app/gateway/assets/locale/locale.constant-en_US.json
+++ b/src/app/gateway/assets/locale/locale.constant-en_US.json
@@ -549,6 +549,7 @@
       "send-period-min": "Statistic send period can not be less then 60",
       "send-period-pattern": "Statistic send period is not valid",
       "check-connectors-configuration": "Check connectors configuration (in sec)",
+      "messages": "Messages",
       "max-payload-size-bytes": "Max payload size in bytes",
       "max-payload-size-bytes-required": "Max payload size in bytes is required",
       "max-payload-size-bytes-min": "Max payload size in bytes can not be less then 100",
@@ -745,7 +746,7 @@
       "poll-period-required": "Poll period is required.",
       "socket": {
         "attribute-on-platform-required": "Attribute on platform is required",
-        "attribute-requests-type": "The type of requested attribute can be “shared” or “client.",
+        "attribute-requests-type": "The type of requested attribute can be “shared” or “client.“",
         "with-response": "Boolean flag that specifies whether to send a response back to platform.",
         "key-telemetry": "Name for telemetry on platform.",
         "key-attribute": "Name for attribute on platform."

--- a/src/app/gateway/assets/locale/locale.constant-en_US.json
+++ b/src/app/gateway/assets/locale/locale.constant-en_US.json
@@ -59,6 +59,7 @@
     "baudrate": "Baudrate",
     "buffer-size": "Buffer size",
     "buffer-size-required": "Buffer size is required",
+    "buffer-size-range": "Buffer size should be greater than 0",
     "bytesize": "Bytesize",
     "boolean": "Boolean",
     "bit": "Bit",

--- a/src/app/gateway/states/gateway-configuration/components/basic/gateway-basic-configuration.component.html
+++ b/src/app/gateway/states/gateway-configuration/components/basic/gateway-basic-configuration.component.html
@@ -62,13 +62,13 @@
             </mat-form-field>
           </div>
         </div>
-        <tb-gateway-security-configuration formControlName="security" [device]="device" (initialCredentialsUpdated)="initialCredentialsUpdated.emit($event)" (initialized)="onInitialized($event)"/>
+        <tb-gateway-security-configuration *ngIf="initialCredentials$ | async" formControlName="security" (initialized)="onInitialized($event)"/>
         <tb-report-strategy *ngIf="withReportStrategy" [defaultValue]="ReportStrategyDefaultValue.Gateway" class="tb-form-panel" formControlName="reportStrategy"/>
       </div>
     </ng-template>
   </mat-tab>
   <mat-tab label="{{ 'gateway.logs.logs' | translate }}">
-    <tb-gateway-logs-configuration formControlName="logs" (initialized)="onInitialized($event)"/>
+    <tb-gateway-logs-configuration class="configuration-block" formControlName="logs" (initialized)="onInitialized($event)"/>
   </mat-tab>
   <mat-tab label="{{ 'gateway.storage' | translate }}">
     <tb-gateway-storage-configuration formControlName="storage" (initialized)="onInitialized($event)"/>
@@ -244,7 +244,10 @@
             </mat-form-field>
             <mat-form-field appearance="outline" class="flex">
               <mat-label translate>gateway.mqtt-qos</mat-label>
-              <input matInput formControlName="qos" type="number" min="0" max="1"/>
+              <mat-select formControlName="qos">
+                <mat-option value="0">0</mat-option>
+                <mat-option value="1">1</mat-option>
+              </mat-select>
               <mat-error *ngIf="basicFormGroup.get('thingsboard.qos').hasError('required')">
                 {{ 'gateway.mqtt-qos-required' | translate }}
               </mat-error>

--- a/src/app/gateway/states/gateway-configuration/components/basic/gateway-basic-configuration.component.ts
+++ b/src/app/gateway/states/gateway-configuration/components/basic/gateway-basic-configuration.component.ts
@@ -16,7 +16,6 @@
 
 import {
   AfterViewInit,
-  ChangeDetectorRef,
   Component,
   EventEmitter,
   forwardRef,
@@ -37,7 +36,7 @@ import {
   ValidationErrors,
   Validators
 } from '@angular/forms';
-import { coerceBoolean, DeviceCredentials, EntityId, SharedModule } from '@shared/public-api';
+import { coerceBoolean, EntityId, SharedModule } from '@shared/public-api';
 import { MatDialog } from '@angular/material/dialog';
 import {
   GatewayRemoteConfigurationDialogComponent,
@@ -64,6 +63,7 @@ import { GatewayStorageConfigurationComponent } from './storage/gateway-storage-
 import { GatewayGrpcConfigurationComponent } from './grpc/gateway-grpc-configuration.component';
 import { GatewayLogsConfigurationComponent } from './logs/gateway-logs-configuration.component';
 import { GatewaySecurityConfigurationComponent } from './security/gateway-security-configuration.component';
+import { GatewayDeviceCredentialsService } from '../../services/gateway-device-credentials.service';
 
 @Component({
   selector: 'tb-gateway-basic-configuration',
@@ -99,7 +99,6 @@ export class GatewayBasicConfigurationComponent implements OnChanges, AfterViewI
   @Input() @coerceBoolean() dialogMode = false;
   @Input() @coerceBoolean() withReportStrategy = false;
 
-  @Output() initialCredentialsUpdated = new EventEmitter<DeviceCredentials>();
   @Output() initialized = new EventEmitter();
 
   @ViewChild('configGroup') configGroup: MatTabGroup;
@@ -108,13 +107,15 @@ export class GatewayBasicConfigurationComponent implements OnChanges, AfterViewI
 
   basicFormGroup: FormGroup;
 
+  readonly initialCredentials$ = this.gatewayCredentialsService.initialCredentials$;
+
   private onChange: (value: GatewayConfigValue) => void = () => {};
 
   private destroy$ = new Subject<void>();
 
   constructor(private fb: FormBuilder,
               private deviceService: DeviceService,
-              private cd: ChangeDetectorRef,
+              private gatewayCredentialsService: GatewayDeviceCredentialsService,
               private dialog: MatDialog) {
     this.initBasicFormGroup();
     this.observeFormChanges();
@@ -236,7 +237,7 @@ export class GatewayBasicConfigurationComponent implements OnChanges, AfterViewI
       handleDeviceRenaming: [true],
       checkingDeviceActivity: this.initCheckingDeviceActivityFormGroup(),
       security: [],
-      qos: [1, [Validators.required, Validators.min(0), Validators.max(1), Validators.pattern(/^[^.\s]+$/)]],
+      qos: ['1'],
       reportStrategy: [{
         value: { type: ReportStrategyType.OnReportPeriod, reportPeriod: ReportStrategyDefaultValue.Gateway },
         disabled: true

--- a/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-security-configuration.component.html
+++ b/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-security-configuration.component.html
@@ -28,15 +28,26 @@
       <mat-error *ngIf="securityFormGroup.get('accessToken').hasError('required')">
         {{ 'security.access-token-required' | translate }}
       </mat-error>
-      <tb-copy-button
-        matSuffix
-        miniButton="false"
-        *ngIf="securityFormGroup.get('accessToken').value"
-        [copyText]="securityFormGroup.get('accessToken').value"
-        tooltipText="{{ 'device.copy-access-token' | translate }}"
-        tooltipPosition="above"
-        icon="content_copy">
-      </tb-copy-button>
+      @if (securityFormGroup.get('accessToken').value) {
+        <tb-copy-button
+          matSuffix
+          miniButton="false"
+          [copyText]="securityFormGroup.get('accessToken').value"
+          tooltipText="{{ 'device.copy-access-token' | translate }}"
+          tooltipPosition="above"
+          icon="content_copy">
+        </tb-copy-button>
+      } @else {
+        <button type="button"
+                matSuffix
+                mat-icon-button
+                aria-label="Generate"
+                matTooltip="{{ 'device.generate-access-token' | translate }}"
+                matTooltipPosition="above"
+                (click)="generateAccessToken()">
+          <mat-icon>autorenew</mat-icon>
+        </button>
+      }
       <mat-icon matIconSuffix style="cursor:pointer;"
                 matTooltip="{{ 'gateway.hints.token' | translate }}">info_outlined
       </mat-icon>

--- a/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-security-configuration.component.ts
+++ b/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-security-configuration.component.ts
@@ -157,7 +157,7 @@ export class GatewaySecurityConfigurationComponent implements AfterViewInit, Con
     }
   }
 
-  public generateAccessToken(): void{
+  public generateAccessToken(): void {
     this.securityFormGroup.get('accessToken').patchValue(generateSecret(20));
   }
 }

--- a/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-security-configuration.component.ts
+++ b/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-security-configuration.component.ts
@@ -17,10 +17,8 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
-  DestroyRef,
   EventEmitter,
   forwardRef,
-  Input,
   Output
 } from '@angular/core';
 import {
@@ -33,15 +31,16 @@ import {
   Validators
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { DeviceCredentials, DeviceCredentialsType, EntityId, SharedModule } from '@shared/public-api';
+import { SharedModule } from '@shared/public-api';
 import {
   GatewayConfigSecurity,
   SecurityTypes,
   SecurityTypesTranslationsMap,
 } from '../../../models/public-api';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { DeviceService } from '@core/public-api';
 import { GatewayUsernameConfigurationComponent } from './gateway-username-configuration/gateway-username-configuration.component';
+import { GatewayDeviceCredentialsService } from '../../../services/gateway-device-credentials.service';
+import { generateSecret } from '@core/public-api';
 
 @Component({
   selector: 'tb-gateway-security-configuration',
@@ -67,8 +66,6 @@ import { GatewayUsernameConfigurationComponent } from './gateway-username-config
 })
 export class GatewaySecurityConfigurationComponent implements AfterViewInit, ControlValueAccessor, Validators {
 
-  @Input() device: EntityId;
-  @Output() initialCredentialsUpdated = new EventEmitter<DeviceCredentials>();
   @Output() initialized = new EventEmitter();
 
   securityFormGroup: FormGroup;
@@ -80,25 +77,23 @@ export class GatewaySecurityConfigurationComponent implements AfterViewInit, Con
   constructor(
     private fb: FormBuilder,
     private cd: ChangeDetectorRef,
-    private deviceService: DeviceService,
-    private destroyRef: DestroyRef,
+    private gatewayCredentialsService: GatewayDeviceCredentialsService,
   ) {
     this.securityFormGroup = this.createSecurityFormGroup();
     this.setupFormListeners();
   }
 
   ngAfterViewInit(): void {
-    this.checkAndFetchCredentials(this.securityFormGroup.value ?? {} as GatewayConfigSecurity);
+    const { usernamePassword, ...value } = this.securityFormGroup.value;
+    this.initialized.emit({ thingsboard: { security: usernamePassword ? { ...value, ...usernamePassword } : value } });
   }
 
   writeValue(value: GatewayConfigSecurity): void {
-    const { clientId, username, password, ...security } = value ?? {} as GatewayConfigSecurity;
-    if (security?.type === SecurityTypes.USERNAME_PASSWORD) {
-      this.securityFormGroup.patchValue({...security, usernamePassword: { clientId, username, password } }, { emitEvent: false });
+    if (value) {
+      this.updateFormBySecurityConfig(value);
     } else {
-      this.securityFormGroup.patchValue(security, { emitEvent: false });
+      this.updateFormBySecurityConfig(this.gatewayCredentialsService.credentialsToSecurityConfig(this.gatewayCredentialsService.initialCredentials));
     }
-    this.toggleBySecurityType(this.securityFormGroup.get('type').value);
   }
 
   registerOnChange(fn: (config: GatewayConfigSecurity) => {}): void {
@@ -113,6 +108,16 @@ export class GatewaySecurityConfigurationComponent implements AfterViewInit, Con
     };
   }
 
+  private updateFormBySecurityConfig(securityConfig: GatewayConfigSecurity): void {
+    const { clientId, username, password, ...security } = securityConfig ?? {} as GatewayConfigSecurity;
+    if (security?.type === SecurityTypes.USERNAME_PASSWORD) {
+      this.securityFormGroup.patchValue({...security, usernamePassword: { clientId, username, password } }, { emitEvent: false });
+    } else {
+      this.securityFormGroup.patchValue(security, { emitEvent: false });
+    }
+    this.toggleBySecurityType(this.securityFormGroup.get('type').value);
+  }
+
   private createSecurityFormGroup(): FormGroup {
     return this.fb.group({
       type: [SecurityTypes.ACCESS_TOKEN, [Validators.required]],
@@ -123,17 +128,13 @@ export class GatewaySecurityConfigurationComponent implements AfterViewInit, Con
   }
 
   private setupFormListeners(): void {
-    this.securityFormGroup.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ usernamePassword, ...value }) => {
+    this.securityFormGroup.valueChanges.pipe(takeUntilDestroyed()).subscribe(({ usernamePassword, ...value }) => {
       this.onChange(usernamePassword ? { ...value, ...usernamePassword } : value);
     });
-    this.listenToSecurityTypeChanges();
-    this.securityFormGroup.get('caCert').valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.cd.detectChanges());
-  }
-
-  private listenToSecurityTypeChanges(): void {
-    this.securityFormGroup.get('type').valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(type => {
+    this.securityFormGroup.get('type').valueChanges.pipe(takeUntilDestroyed()).subscribe(type => {
       this.toggleBySecurityType(type);
     });
+    this.securityFormGroup.get('caCert').valueChanges.pipe(takeUntilDestroyed()).subscribe(() => this.cd.detectChanges());
   }
 
   private toggleBySecurityType(type: SecurityTypes): void {
@@ -156,63 +157,7 @@ export class GatewaySecurityConfigurationComponent implements AfterViewInit, Con
     }
   }
 
-  private checkAndFetchCredentials(security: GatewayConfigSecurity): void {
-    if (security.type === SecurityTypes.TLS_PRIVATE_KEY) {
-      return;
-    }
-
-    this.deviceService.getDeviceCredentials(this.device.id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(credentials => {
-      this.updateSecurityType(security, credentials);
-      this.updateCredentials(credentials, security);
-      this.initialCredentialsUpdated.emit({...credentials, version: null} as DeviceCredentials);
-      this.initialized.emit({ thingsboard: { security: this.securityFormGroup.value } });
-    });
-  }
-
-  private updateSecurityType(security: GatewayConfigSecurity, credentials: DeviceCredentials): void {
-    const securityType = this.determineSecurityType(security, credentials);
-    if (securityType) {
-      this.securityFormGroup.get('type').setValue(securityType, { emitEvent: false });
-      this.toggleBySecurityType(securityType);
-    }
-  }
-
-  private determineSecurityType(security: GatewayConfigSecurity, credentials: DeviceCredentials): SecurityTypes | null {
-    const isAccessToken = credentials.credentialsType === DeviceCredentialsType.ACCESS_TOKEN
-      || security.type === SecurityTypes.TLS_ACCESS_TOKEN;
-    if (isAccessToken) {
-      return security.type === SecurityTypes.TLS_ACCESS_TOKEN ? SecurityTypes.TLS_ACCESS_TOKEN : SecurityTypes.ACCESS_TOKEN;
-    }
-    return credentials.credentialsType === DeviceCredentialsType.MQTT_BASIC ? SecurityTypes.USERNAME_PASSWORD : null;
-  }
-
-  private updateCredentials(credentials: DeviceCredentials, security: GatewayConfigSecurity): void {
-    switch (credentials.credentialsType) {
-      case DeviceCredentialsType.ACCESS_TOKEN:
-        this.updateAccessTokenCredentials(credentials, security);
-        break;
-      case DeviceCredentialsType.MQTT_BASIC:
-        this.updateMqttBasicCredentials(credentials);
-        break;
-      case DeviceCredentialsType.X509_CERTIFICATE:
-        // Handle X509 certificate if needed
-        break;
-    }
-  }
-
-  private updateAccessTokenCredentials(credentials: DeviceCredentials, security: GatewayConfigSecurity): void {
-    this.securityFormGroup.get('accessToken').setValue(credentials.credentialsId, { emitEvent: false });
-    if (security.type === SecurityTypes.TLS_ACCESS_TOKEN) {
-      this.securityFormGroup.get('caCert').setValue(security.caCert, { emitEvent: false });
-    }
-  }
-
-  private updateMqttBasicCredentials(credentials: DeviceCredentials): void {
-    const parsedValue = JSON.parse(credentials.credentialsValue);
-    this.securityFormGroup.patchValue({
-      clientId: parsedValue.clientId,
-      username: parsedValue.userName,
-      password: parsedValue.password
-    }, { emitEvent: false });
+  public generateAccessToken(): void{
+    this.securityFormGroup.get('accessToken').patchValue(generateSecret(20));
   }
 }

--- a/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-username-configuration/gateway-username-configuration.component.html
+++ b/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-username-configuration/gateway-username-configuration.component.html
@@ -67,7 +67,7 @@
                 matSuffix
                 mat-icon-button
                 aria-label="Generate"
-                matTooltip="{{ 'device.generate-username' | translate }}"
+                matTooltip="{{ 'device.generate-user-name' | translate }}"
                 matTooltipPosition="above"
                 (click)="generate('username')">
           <mat-icon>autorenew</mat-icon>

--- a/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-username-configuration/gateway-username-configuration.component.html
+++ b/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-username-configuration/gateway-username-configuration.component.html
@@ -21,15 +21,27 @@
       <mat-error *ngIf="usernameFormGroup.get('clientId').hasError('required')">
         {{ 'security.clientId-required' | translate }}
       </mat-error>
-      <tb-copy-button
-        matSuffix
-        miniButton="false"
-        *ngIf="usernameFormGroup.get('clientId').value"
-        [copyText]="usernameFormGroup.get('clientId').value"
-        tooltipText="{{ 'gateway.copy-client-id' | translate }}"
-        tooltipPosition="above"
-        icon="content_copy">
-      </tb-copy-button>
+      @if (usernameFormGroup.get('clientId').value) {
+        <tb-copy-button
+          matSuffix
+          miniButton="false"
+          *ngIf="usernameFormGroup.get('clientId').value"
+          [copyText]="usernameFormGroup.get('clientId').value"
+          tooltipText="{{ 'gateway.copy-client-id' | translate }}"
+          tooltipPosition="above"
+          icon="content_copy">
+        </tb-copy-button>
+      } @else {
+        <button type="button"
+                matSuffix
+                mat-icon-button
+                aria-label="Generate"
+                matTooltip="{{ 'device.generate-client-id' | translate }}"
+                matTooltipPosition="above"
+                (click)="generate('clientId')">
+          <mat-icon>autorenew</mat-icon>
+        </button>
+      }
       <mat-icon matIconSuffix style="cursor:pointer;"
                 matTooltip="{{ 'gateway.hints.client-id' | translate }}">info_outlined
       </mat-icon>
@@ -40,15 +52,27 @@
       <mat-error *ngIf="usernameFormGroup.get('username').hasError('required')">
         {{ 'security.username-required' | translate }}
       </mat-error>
-      <tb-copy-button
-        matSuffix
-        miniButton="false"
-        *ngIf="usernameFormGroup.get('username').value"
-        [copyText]="usernameFormGroup.get('username').value"
-        tooltipText="{{ 'gateway.copy-username' | translate }}"
-        tooltipPosition="above"
-        icon="content_copy">
-      </tb-copy-button>
+      @if (usernameFormGroup.get('username').value) {
+        <tb-copy-button
+          matSuffix
+          miniButton="false"
+          *ngIf="usernameFormGroup.get('username').value"
+          [copyText]="usernameFormGroup.get('username').value"
+          tooltipText="{{ 'gateway.copy-username' | translate }}"
+          tooltipPosition="above"
+          icon="content_copy">
+        </tb-copy-button>
+      } @else {
+        <button type="button"
+                matSuffix
+                mat-icon-button
+                aria-label="Generate"
+                matTooltip="{{ 'device.generate-username' | translate }}"
+                matTooltipPosition="above"
+                (click)="generate('username')">
+          <mat-icon>autorenew</mat-icon>
+        </button>
+      }
       <mat-icon matIconSuffix style="cursor:pointer;"
                 matTooltip="{{ 'gateway.hints.username' | translate }}">info_outlined
       </mat-icon>
@@ -57,15 +81,27 @@
   <mat-form-field appearance="outline" subscriptSizing="dynamic" style="width: 100%">
     <mat-label translate>gateway.password</mat-label>
     <input matInput formControlName="password"/>
-    <tb-copy-button
-      matSuffix
-      miniButton="false"
-      *ngIf="usernameFormGroup.get('password').value"
-      [copyText]="usernameFormGroup.get('password').value"
-      tooltipText="{{ 'gateway.copy-password' | translate }}"
-      tooltipPosition="above"
-      icon="content_copy">
-    </tb-copy-button>
+    @if (usernameFormGroup.get('password').value) {
+      <tb-copy-button
+        matSuffix
+        miniButton="false"
+        *ngIf="usernameFormGroup.get('password').value"
+        [copyText]="usernameFormGroup.get('password').value"
+        tooltipText="{{ 'gateway.copy-password' | translate }}"
+        tooltipPosition="above"
+        icon="content_copy">
+      </tb-copy-button>
+    } @else {
+      <button type="button"
+              matSuffix
+              mat-icon-button
+              aria-label="Generate"
+              matTooltip="{{ 'device.generate-password' | translate }}"
+              matTooltipPosition="above"
+              (click)="generate('password')">
+        <mat-icon>autorenew</mat-icon>
+      </button>
+    }
     <mat-icon matIconSuffix style="cursor:pointer;"
               matTooltip="{{ 'gateway.hints.password' | translate }}">info_outlined
     </mat-icon>

--- a/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-username-configuration/gateway-username-configuration.component.html
+++ b/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-username-configuration/gateway-username-configuration.component.html
@@ -25,7 +25,6 @@
         <tb-copy-button
           matSuffix
           miniButton="false"
-          *ngIf="usernameFormGroup.get('clientId').value"
           [copyText]="usernameFormGroup.get('clientId').value"
           tooltipText="{{ 'gateway.copy-client-id' | translate }}"
           tooltipPosition="above"
@@ -56,7 +55,6 @@
         <tb-copy-button
           matSuffix
           miniButton="false"
-          *ngIf="usernameFormGroup.get('username').value"
           [copyText]="usernameFormGroup.get('username').value"
           tooltipText="{{ 'gateway.copy-username' | translate }}"
           tooltipPosition="above"
@@ -85,7 +83,6 @@
       <tb-copy-button
         matSuffix
         miniButton="false"
-        *ngIf="usernameFormGroup.get('password').value"
         [copyText]="usernameFormGroup.get('password').value"
         tooltipText="{{ 'gateway.copy-password' | translate }}"
         tooltipPosition="above"

--- a/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-username-configuration/gateway-username-configuration.component.ts
+++ b/src/app/gateway/states/gateway-configuration/components/basic/security/gateway-username-configuration/gateway-username-configuration.component.ts
@@ -13,7 +13,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 ///
-import { Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
+import { Component, forwardRef } from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -24,9 +24,10 @@ import {
   Validators
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { DeviceCredentials, EntityId, SharedModule } from '@shared/public-api';
+import { SharedModule } from '@shared/public-api';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GatewayUsernamePasswordConfig } from '../../../../models/public-api';
+import { generateSecret } from '@core/public-api';
 
 @Component({
   selector: 'tb-gateway-username-configuration',
@@ -50,9 +51,6 @@ import { GatewayUsernamePasswordConfig } from '../../../../models/public-api';
   ]
 })
 export class GatewayUsernameConfigurationComponent implements ControlValueAccessor, Validators {
-
-  @Input() device: EntityId;
-  @Output() initialCredentialsUpdated = new EventEmitter<DeviceCredentials>();
 
   usernameFormGroup: FormGroup;
 
@@ -123,5 +121,9 @@ export class GatewayUsernameConfigurationComponent implements ControlValueAccess
     }
 
     return null;
+  }
+
+  public generate(formControlName: string): void {
+    this.usernameFormGroup.get(formControlName).patchValue(generateSecret(20));
   }
 }

--- a/src/app/gateway/states/gateway-configuration/gateway-configuration.component.html
+++ b/src/app/gateway/states/gateway-configuration/gateway-configuration.component.html
@@ -41,7 +41,6 @@
       [defaultTab]="defaultTab"
       [dialogMode]="!!dialogRef"
       [withReportStrategy]="gatewayVersion | withReportStrategy"
-      (initialCredentialsUpdated)="onInitialCredentialsUpdate($event)"
       (initialized)="onInitialized($event)"
     />
     <tb-gateway-advanced-configuration

--- a/src/app/gateway/states/gateway-configuration/gateway-configuration.component.ts
+++ b/src/app/gateway/states/gateway-configuration/gateway-configuration.component.ts
@@ -202,7 +202,7 @@ export class GatewayConfigurationComponent implements AfterViewInit {
           stream: 'ext://sys.stdout'
         },
         databaseHandler: {
-          class: 'thingsboard_gateway.tb_utility.tb_handler.TimedRotatingFileHandler',
+          class: 'thingsboard_gateway.tb_utility.tb_rotating_file_handler.TimedRotatingFileHandler',
           formatter: 'LogFormatter',
           filename: './logs/database.log',
           backupCount: 1,
@@ -241,7 +241,7 @@ export class GatewayConfigurationComponent implements AfterViewInit {
 
   private createHandlerObj(logObj: LogConfig, key: string) {
     return {
-      class: 'thingsboard_gateway.tb_utility.tb_handler.TimedRotatingFileHandler',
+      class: 'thingsboard_gateway.tb_utility.tb_rotating_file_handler.TimedRotatingFileHandler',
       formatter: 'LogFormatter',
       filename: `${logObj.filePath}/${key}.log`,
       backupCount: logObj.backupCount,

--- a/src/app/gateway/states/gateway-configuration/services/gateway-device-credentials.service.ts
+++ b/src/app/gateway/states/gateway-configuration/services/gateway-device-credentials.service.ts
@@ -1,3 +1,18 @@
+///
+/// Copyright © 2016-2024 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
 import { DestroyRef, Injectable } from '@angular/core';
 import { GatewayConfigSecurity, SecurityTypes } from '../models/gateway-configuration.models';
 import { DeviceCredentials, DeviceCredentialsType, DeviceId } from '@shared/public-api';

--- a/src/app/gateway/states/gateway-configuration/services/gateway-device-credentials.service.ts
+++ b/src/app/gateway/states/gateway-configuration/services/gateway-device-credentials.service.ts
@@ -1,0 +1,110 @@
+import { DestroyRef, Injectable } from '@angular/core';
+import { GatewayConfigSecurity, SecurityTypes } from '../models/gateway-configuration.models';
+import { DeviceCredentials, DeviceCredentialsType, DeviceId } from '@shared/public-api';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { DeviceService } from '@core/public-api';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+@Injectable()
+export class GatewayDeviceCredentialsService {
+
+  private initialCredentialsSubject = new BehaviorSubject<DeviceCredentials>(null);
+
+  constructor(private deviceService: DeviceService, private destroyRef: DestroyRef) {
+  }
+
+  get initialCredentials(): DeviceCredentials {
+    return this.initialCredentialsSubject.value;
+  }
+
+  get initialCredentials$(): Observable<DeviceCredentials> {
+    return this.initialCredentialsSubject.asObservable();
+  }
+
+  updateCredentials(securityConfig: GatewayConfigSecurity): Observable<DeviceCredentials> {
+    let newCredentials: Partial<DeviceCredentials> = {};
+
+    switch (securityConfig.type) {
+      case SecurityTypes.USERNAME_PASSWORD:
+        if (this.shouldUpdateCredentials(securityConfig)) {
+          newCredentials = this.generateMqttCredentials(securityConfig);
+        }
+        break;
+
+      case SecurityTypes.ACCESS_TOKEN:
+      case SecurityTypes.TLS_ACCESS_TOKEN:
+        if (this.shouldUpdateAccessToken(securityConfig)) {
+          newCredentials = {
+            credentialsType: DeviceCredentialsType.ACCESS_TOKEN,
+            credentialsId: securityConfig.accessToken,
+            credentialsValue: null
+          };
+        }
+        break;
+    }
+
+    return Object.keys(newCredentials).length
+      ? this.deviceService.saveDeviceCredentials({ ...this.initialCredentials, ...newCredentials })
+      : of(null);
+  }
+
+  setInitialCredentials(deviceId: DeviceId): void {
+    this.deviceService.getDeviceCredentials(deviceId.id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(credentials => {
+      this.initialCredentialsSubject.next({...credentials, version: null} as DeviceCredentials);
+    });
+  }
+
+  shouldUpdateSecurityConfig(securityConfig: GatewayConfigSecurity): boolean {
+    switch (securityConfig.type) {
+      case SecurityTypes.USERNAME_PASSWORD:
+        return this.shouldUpdateCredentials(securityConfig);
+      case SecurityTypes.ACCESS_TOKEN:
+      case SecurityTypes.TLS_ACCESS_TOKEN:
+        return this.shouldUpdateAccessToken(securityConfig);
+    }
+  }
+
+  credentialsToSecurityConfig(credentials: DeviceCredentials): GatewayConfigSecurity {
+    const securityConfig = {
+      type: credentials.credentialsType === DeviceCredentialsType.MQTT_BASIC ? SecurityTypes.USERNAME_PASSWORD : SecurityTypes.ACCESS_TOKEN,
+      accessToken: credentials.credentialsId,
+    }
+    if (credentials.credentialsValue) {
+      const { clientId, userName, password } = JSON.parse(credentials.credentialsValue);
+      return { ...securityConfig, clientId, username: userName, password } as GatewayConfigSecurity;
+    }
+    return securityConfig;
+  }
+
+  private shouldUpdateCredentials(securityConfig: GatewayConfigSecurity): boolean {
+    if (this.initialCredentials.credentialsType !== DeviceCredentialsType.MQTT_BASIC) {
+      return true;
+    }
+    const parsedCredentials = JSON.parse(this.initialCredentials.credentialsValue);
+    return !(
+      parsedCredentials.clientId === securityConfig.clientId &&
+      parsedCredentials.userName === securityConfig.username &&
+      parsedCredentials.password === securityConfig.password
+    );
+  }
+
+  private shouldUpdateAccessToken(securityConfig: GatewayConfigSecurity): boolean {
+    return this.initialCredentials.credentialsType !== DeviceCredentialsType.ACCESS_TOKEN ||
+      this.initialCredentials.credentialsId !== securityConfig.accessToken;
+  }
+
+  private generateMqttCredentials(securityConfig: GatewayConfigSecurity): Partial<DeviceCredentials> {
+    const { clientId, username, password } = securityConfig;
+
+    const credentialsValue = {
+      ...(clientId && { clientId }),
+      ...(username && { userName: username }),
+      ...(password && { password }),
+    };
+
+    return {
+      credentialsType: DeviceCredentialsType.MQTT_BASIC,
+      credentialsValue: JSON.stringify(credentialsValue)
+    };
+  }
+}

--- a/src/app/gateway/states/gateway-configuration/services/public-api.ts
+++ b/src/app/gateway/states/gateway-configuration/services/public-api.ts
@@ -1,0 +1,1 @@
+export * from './gateway-device-credentials.service';

--- a/src/app/gateway/states/gateway-configuration/services/public-api.ts
+++ b/src/app/gateway/states/gateway-configuration/services/public-api.ts
@@ -1,1 +1,16 @@
+///
+/// Copyright © 2016-2024 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
 export * from './gateway-device-credentials.service';

--- a/src/app/gateway/states/gateway-connectors/components/bacnet/devices-config-table/bacnet-devices-config-table.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/bacnet/devices-config-table/bacnet-devices-config-table.component.html
@@ -82,10 +82,7 @@
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="actions" stickyEnd>
-          <mat-header-cell *matHeaderCellDef>
-            <div class="gt-md:!hidden" style="width: 48px; min-width: 48px; max-width: 48px;"></div>
-            <div class="lt-lg:!hidden" [style]="{ minWidth: '96px', textAlign: 'center'}"></div>
-          </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="w-12"/>
           <mat-cell *matCellDef="let device; let i = index">
             <ng-template #rowActions>
               <button mat-icon-button

--- a/src/app/gateway/states/gateway-connectors/components/bacnet/devices-config-table/bacnet-devices-config-table.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/bacnet/devices-config-table/bacnet-devices-config-table.component.scss
@@ -53,7 +53,7 @@
 
           .table-value-column {
             padding: 0 12px;
-            width: 23%;
+            width: 21%;
           }
         }
       }

--- a/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.html
@@ -56,7 +56,7 @@
                         </mat-icon>
                         <div matSuffix
                              class="see-example"
-                             *ngIf="connectorType | getConnectorMappingHelpLink : this.keysType : keyControl.get('typeValue').value?.type : convertorType"
+                             *ngIf="connectorType === ConnectorType.MQTT && connectorType | getConnectorMappingHelpLink : this.keysType : keyControl.get('typeValue').value?.type : convertorType"
                              [tb-help-popup]="connectorType | getConnectorMappingHelpLink : this.keysType : keyControl.get('typeValue').value?.type : convertorType"
                              tb-help-popup-placement="left"
                              [tb-help-popup-style]="{maxWidth: '970px'}">

--- a/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.ts
@@ -89,6 +89,7 @@ export class MappingDataKeysPanelComponent extends PageComponent implements OnIn
 
   readonly MappingKeysType = MappingKeysType;
   readonly ReportStrategyDefaultValue = ReportStrategyDefaultValue;
+  readonly ConnectorType = ConnectorType;
 
   keysListFormArray: UntypedFormArray;
 

--- a/src/app/gateway/states/gateway-connectors/components/mapping-dialog/mapping-dialog.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-dialog/mapping-dialog.component.ts
@@ -153,7 +153,7 @@ export class MappingDialogComponent extends DialogComponent<MappingDialogCompone
   }
 
   get converterType(): ConvertorType {
-    return this.mappingForm.get('converter').get('type').value;
+    return this.mappingForm.get('converter')?.get('type').value;
   }
 
   get customKeys(): Array<string> {

--- a/src/app/gateway/states/gateway-connectors/components/mapping-table/mapping-table.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-table/mapping-table.component.html
@@ -68,10 +68,7 @@
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="actions" stickyEnd>
-          <mat-header-cell *matHeaderCellDef>
-            <div class="gt-md:!hidden" style="width: 48px; min-width: 48px; max-width: 48px;"></div>
-            <div class="lt-lg:!hidden" [style]="{ minWidth: '96px', textAlign: 'center'}"></div>
-          </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="w-12"/>
           <mat-cell *matCellDef="let mapping; let i = index">
             <ng-template #rowActions>
               <button mat-icon-button

--- a/src/app/gateway/states/gateway-connectors/components/mapping-table/mapping-table.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-table/mapping-table.component.scss
@@ -56,10 +56,10 @@
 
           .table-value-column {
             padding: 0 12px;
-            width: 23%;
+            width: 21%;
 
             &.request-column {
-              width: 38%;
+              width: 35%;
             }
           }
         }

--- a/src/app/gateway/states/gateway-connectors/components/modbus/modbus-data-keys-panel/modbus-data-keys-panel.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/modbus/modbus-data-keys-panel/modbus-data-keys-panel.component.html
@@ -43,7 +43,7 @@
                 </mat-panel-title>
               </mat-expansion-panel-header>
               <ng-template matExpansionPanelContent>
-                <div class="tb-form-hint tb-primary-fill tb-flex center align-center">
+                <div class="tb-form-hint tb-primary-fill tb-flex align-center">
                   {{ 'gateway.hints.modbus.data-keys' | translate }}
                   <div matSuffix
                        class="see-example"

--- a/src/app/gateway/states/gateway-connectors/components/modbus/modbus-master-table/modbus-master-table.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/modbus/modbus-master-table/modbus-master-table.component.html
@@ -15,7 +15,7 @@
 -->
 <div class="tb-master-table tb-absolute-fill">
   <div class="tb-form-panel no-border no-padding padding-top hint-container">
-    <div class="tb-form-hint tb-primary-fill tb-flex center" tbTruncateWithTooltip>{{ 'gateway.hints.modbus-master' | translate }}</div>
+    <div class="tb-form-hint tb-primary-fill tb-flex" tbTruncateWithTooltip>{{ 'gateway.hints.modbus-master' | translate }}</div>
   </div>
   <div class="tb-master-table-content flex flex-col">
     <mat-toolbar class="mat-mdc-table-toolbar" [class.!hidden]="textSearchMode">
@@ -93,10 +93,7 @@
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="actions" stickyEnd>
-          <mat-header-cell *matHeaderCellDef>
-            <div class="gt-md:!hidden" style="width: 48px; min-width: 48px; max-width: 48px;"></div>
-            <div class="lt-lg:!hidden" [style]="{ minWidth: '48px', textAlign: 'center'}"></div>
-          </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="w-12"/>
           <mat-cell *matCellDef="let slave; let i = index">
             <ng-template #rowActions>
               <button mat-icon-button

--- a/src/app/gateway/states/gateway-connectors/components/modbus/modbus-master-table/modbus-master-table.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/modbus/modbus-master-table/modbus-master-table.component.scss
@@ -53,7 +53,7 @@
 
           .table-value-column {
             padding: 0 12px;
-            width: 16%;
+            width: 15%;
           }
         }
       }

--- a/src/app/gateway/states/gateway-connectors/components/socket/device-dialog/device-dialog.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/socket/device-dialog/device-dialog.component.html
@@ -32,12 +32,6 @@
           <div class="tb-required" translate>
             gateway.address-filter
           </div>
-          <div  matSuffix
-                class="see-example"
-                [tb-help-popup]="'widget/lib/gateway/address-filter_fn'"
-                tb-help-popup-placement="left"
-                [tb-help-popup-style]="{maxWidth: '970px'}">
-          </div>
         </div>
         <div class="tb-flex no-gap">
           <mat-form-field class="tb-flex no-gap" appearance="outline" subscriptSizing="dynamic">
@@ -52,6 +46,12 @@
                       class="tb-error">
               warning
             </mat-icon>
+            <div  matSuffix
+                  class="see-example"
+                  [tb-help-popup]="'widget/lib/gateway/address-filter_fn'"
+                  tb-help-popup-placement="left"
+                  [tb-help-popup-style]="{maxWidth: '970px'}">
+            </div>
           </mat-form-field>
         </div>
       </div>

--- a/src/app/gateway/states/gateway-connectors/components/socket/devices-config-table/devices-config-table.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/socket/devices-config-table/devices-config-table.component.html
@@ -74,10 +74,7 @@
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="actions" stickyEnd>
-          <mat-header-cell *matHeaderCellDef>
-            <div class="gt-md:!hidden" style="width: 48px; min-width: 48px; max-width: 48px;"></div>
-            <div class="lt-lg:!hidden" [style]="{ minWidth: '96px', textAlign: 'center'}"></div>
-          </mat-header-cell>
+          <mat-header-cell *matHeaderCellDef class="w-12"/>
           <mat-cell *matCellDef="let device; let i = index">
             <ng-template #rowActions>
               <button mat-icon-button

--- a/src/app/gateway/states/gateway-connectors/components/socket/devices-config-table/devices-config-table.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/socket/devices-config-table/devices-config-table.component.scss
@@ -53,7 +53,7 @@
 
           .table-value-column {
             padding: 0 12px;
-            width: 38%;
+            width: 35%;
           }
         }
       }

--- a/src/app/gateway/states/gateway-connectors/components/socket/socket-config/socket-config.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/socket/socket-config/socket-config.component.html
@@ -70,7 +70,7 @@
         <mat-icon matSuffix
                   matTooltipPosition="above"
                   matTooltipClass="tb-error-tooltip"
-                  [matTooltip]="('gateway.buffer-size-required') | translate"
+                  [matTooltip]="(socketConfigFormGroup.get('bufferSize').hasError('min') ? 'gateway.buffer-size-range' : 'gateway.buffer-size-required') | translate"
                   *ngIf="socketConfigFormGroup.get('bufferSize').hasError('required')
                          || socketConfigFormGroup.get('bufferSize').hasError('min')
                          && socketConfigFormGroup.get('bufferSize').touched"

--- a/src/app/gateway/states/gateway-connectors/components/socket/socket-config/socket-config.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/socket/socket-config/socket-config.component.html
@@ -65,14 +65,15 @@
     </div>
     <div class="tb-flex no-gap">
       <mat-form-field class="tb-flex no-gap" appearance="outline" subscriptSizing="dynamic">
-        <input matInput type="number" name="value" min="0" formControlName="bufferSize"
+        <input matInput type="number" name="value" min="1" formControlName="bufferSize"
                placeholder="{{ 'gateway.set' | translate }}"/>
         <mat-icon matSuffix
                   matTooltipPosition="above"
                   matTooltipClass="tb-error-tooltip"
                   [matTooltip]="('gateway.buffer-size-required') | translate"
                   *ngIf="socketConfigFormGroup.get('bufferSize').hasError('required')
-                                           && socketConfigFormGroup.get('bufferSize').touched"
+                         || socketConfigFormGroup.get('bufferSize').hasError('min')
+                         && socketConfigFormGroup.get('bufferSize').touched"
                   class="tb-error">
           warning
         </mat-icon>

--- a/src/app/gateway/states/gateway-connectors/components/socket/socket-config/socket-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/socket/socket-config/socket-config.component.ts
@@ -75,7 +75,7 @@ export class SocketConfigComponent implements ControlValueAccessor, Validator, O
       address: ['', [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]],
       type: [SocketType.TCP],
       port: [50000, [Validators.required, Validators.min(PortLimits.MIN), Validators.max(PortLimits.MAX)]],
-      bufferSize: [1024, [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]]
+      bufferSize: [1024, [Validators.required, Validators.min(1), Validators.pattern(noLeadTrailSpacesRegex)]]
     });
 
     this.socketConfigFormGroup.valueChanges

--- a/src/app/gateway/states/gateway-connectors/components/type-value-field/type-value-field.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/type-value-field/type-value-field.component.html
@@ -70,6 +70,7 @@
       <div matSuffix
            class="see-example"
            *ngIf="helpLink"
+           (click)="$event.stopPropagation()"
            [tb-help-popup]="helpLink"
            tb-help-popup-placement="left"
            [tb-help-popup-style]="{maxWidth: '970px'}">

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.ts
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.ts
@@ -113,7 +113,6 @@ export class ForceErrorStateMatcher implements ErrorStateMatcher {
     SocketBasicConfigComponent,
     SocketLegacyBasicConfigComponent,
     ReportStrategyComponent,
-    AddConnectorDialogComponent,
     BacnetBasicConfigComponent,
     BacnetLegacyBasicConfigComponent
   ],

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.ts
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.ts
@@ -564,12 +564,13 @@ export class GatewayConnectorComponent extends PageComponent implements AfterVie
   }
 
   private setInitialConnectorValues(connector: GatewayConnector): void {
-    const {basicConfig, mode, ...initialConnector} = connector;
+    const {basicConfig, mode, enableRemoteLogging, ...initialConnector} = connector;
     this.toggleReportStrategy(connector);
     this.connectorForm.get('mode').setValue(this.allowBasicConfig.has(connector.type)
       ? connector.mode ?? ConfigurationModes.BASIC
       : null, {emitEvent: false}
     );
+    this.connectorForm.get('enableRemoteLogging').setValue(enableRemoteLogging, {emitEvent: false});
     this.connectorForm.patchValue(initialConnector, {emitEvent: false});
   }
 

--- a/src/app/gateway/states/gateway-service-rpc/components/opc-rpc-parameters/opc-rpc-parameters.component.ts
+++ b/src/app/gateway/states/gateway-service-rpc/components/opc-rpc-parameters/opc-rpc-parameters.component.ts
@@ -111,7 +111,7 @@ export class OpcRpcParametersComponent implements ControlValueAccessor, Validato
 
   writeValue(params: RPCTemplateConfigOPC): void {
     this.clearArguments();
-    params.arguments?.map(({type, value}) => ({type, [type]: value }))
+    params.arguments?.map(({type, value}) => ({type, [type + 'Value']: value }))
       .forEach(argument => this.addArgument(argument as OPCTypeValue));
     this.cdr.markForCheck();
     this.rpcParametersFormGroup.get('method').patchValue(params.method);


### PR DESCRIPTION
Gateway fixes and improvements

## Gateway fixes and improvements list: 
- Added generate button to Gateway security 
![image](https://github.com/user-attachments/assets/ed187f02-82fd-4bb7-9c0f-689233c09a12)
- Gateway Configuration Logs scroll fix 
![image](https://github.com/user-attachments/assets/c0154ccc-c194-4b28-9943-17e3f7042ebd)
- Gateway Configuration qos to select 
![image](https://github.com/user-attachments/assets/b9bbdd2a-6adf-4202-8e90-d74c4e64b391)
- Gateway security Initial credentials fix and security rework
- Basic config tables actions visibility on Mac OS fix
- Align Modbus hints to left improvement
![image](https://github.com/user-attachments/assets/fb1a1962-0b8a-42a9-8dca-7d254d1b4812)
- Socket Device address show help reposition 
![image](https://github.com/user-attachments/assets/daeb5d57-4985-46b6-b9dd-7eac9d684f88)
- Socket bufferSize min 1 fix
- Changed logs handlers class
- OPC parameters fix