### PR TITLE
Aligned master with 4.0 changes and fixes

### DIFF
--- a/src/app/gateway/assets/locale/locale.constant-en_US.json
+++ b/src/app/gateway/assets/locale/locale.constant-en_US.json
@@ -530,6 +530,7 @@
     "set": "Set",
     "show-map": "Show map",
     "statistics": {
+      "custom-send-period": "Custom send period (in sec)",
       "attributes": "Attributes",
       "name-already-exists": "Attribute name already exists.",
       "telemetry": "Telemetry",

--- a/src/app/gateway/assets/locale/locale.constant-en_US.json
+++ b/src/app/gateway/assets/locale/locale.constant-en_US.json
@@ -156,7 +156,7 @@
       "device-profile-expression-required": "Device profile expression is required."
     },
     "device-name-filter": "Device name filter",
-    "device-name-filter-hint": "This field supports Regular expressions to filter incoming data by device name.",
+    "device-name-filter-hint": "This field supports regular expressions to filter incoming data by device name.",
     "device-name-filter-required": "Device name filter is required.",
     "details": "Details",
     "delete-mapping-title": "Delete mapping?",
@@ -218,7 +218,7 @@
     "extension-hint": "Put your converter classname in the field. Custom converter with such class should be in extension/mqtt folder.",
     "extension-required": "Extension is required.",
     "extension-configuration": "Extension configuration",
-    "extension-configuration-hint": "Configuration for convertor",
+    "extension-configuration-hint": "Configuration for converter. These arguments will be passed as a config to convert function.",
     "fill-connector-defaults": "Fill configuration with default values",
     "fill-connector-defaults-hint": "This property allows to fill connector configuration with default values on it's creation.",
     "from-device-request-settings": "Input request parsing",
@@ -283,7 +283,7 @@
     "discrete_inputs": "Discrete inputs",
     "json-parse": "Not valid JSON.",
     "json-required": "Field cannot be empty.",
-    "JSONPath-hint": "This field supports constants and JSONPath expressions.",
+    "JSONPath-hint": "Supports constants and JSONPath expressions to extract data.",
     "logs": {
       "logs": "Logs",
       "days": "days",
@@ -475,7 +475,7 @@
     "request-topic-expression": "Request topic expression",
     "request-client-certificate": "Request client certificate",
     "request-topic-expression-required": "Request topic expression is required.",
-    "response-timeout": "Response timeout (ms)",
+    "response-timeout": "Response timeout",
     "response-timeout-required": "Response timeout is required.",
     "response-timeout-limits-error": "Timeout must be more then {{min}} ms.",
     "response-topic-Qos": "Response topic QoS",
@@ -610,6 +610,7 @@
       "sqlite": "SQLITE"
     },
     "suffix": {
+      "s": "s",
       "ms": "ms"
     },
     "report-strategy": {
@@ -626,7 +627,8 @@
       "const": "Constant",
       "identifier": "Identifier",
       "path": "Path",
-      "expression": "Expression"
+      "expression": "Expression",
+      "request": "From request"
     },
     "workers-settings": "Workers settings",
     "thingsboard": "ThingsBoard",
@@ -644,7 +646,7 @@
     "thingsboard-port-required": "Port is required.",
     "tidy": "Tidy",
     "tidy-tip": "Tidy config JSON",
-    "timeout": "Timeout (ms)",
+    "timeout": "Timeout",
     "timeout-error": "Timeout should be at least {{min}} (ms).",
     "title-connectors-json": "Connector {{typeName}} configuration",
     "type": "Type",

--- a/src/app/gateway/shared/components/error-icon/error-icon.component.ts
+++ b/src/app/gateway/shared/components/error-icon/error-icon.component.ts
@@ -1,0 +1,51 @@
+///
+/// Copyright © 2016-2024 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+import { Component, Input } from '@angular/core';
+import { SharedModule } from '@shared/public-api';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'tb-error-icon',
+  template: `
+    <mat-icon
+      matTooltipPosition="above"
+      matTooltipClass="tb-error-tooltip"
+      [matTooltip]="tooltipText"
+      class="tb-error"
+    >
+      warning
+    </mat-icon>
+  `,
+  standalone: true,
+  imports: [
+    SharedModule,
+    CommonModule,
+  ],
+  styles: [`
+    :host {
+      display: flex;
+      width: 40px;
+      height: 40px;
+      padding: 10px;
+    }
+    mat-icon {
+      font-size: 20px;
+    }
+  `]
+})
+export class ErrorTooltipIconComponent {
+  @Input() tooltipText: string = '';
+}

--- a/src/app/gateway/shared/components/gateway-status/gateway-status.component.html
+++ b/src/app/gateway/shared/components/gateway-status/gateway-status.component.html
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<mat-card class="min-h-10 flex-1 flex justify-center" [class.divider-red]="!isGatewayActive" [class.divider-green]="isGatewayActive">
+<mat-card class="flex min-h-10 flex-1 justify-center" [class.divider-red]="!isGatewayActive" [class.divider-green]="isGatewayActive">
   <div class="divider"></div>
   <mat-card-header>
     <mat-card-subtitle class="whitespace-nowrap">{{ 'gateway.gateway-status' | translate }}</mat-card-subtitle>

--- a/src/app/gateway/shared/components/public-api.ts
+++ b/src/app/gateway/shared/components/public-api.ts
@@ -15,3 +15,4 @@
 ///
 export * from './report-strategy/report-strategy.component';
 export * from './gateway-status/gateway-status.component';
+export * from './error-icon/error-icon.component';

--- a/src/app/gateway/shared/components/report-strategy/report-strategy.component.html
+++ b/src/app/gateway/shared/components/report-strategy/report-strategy.component.html
@@ -35,7 +35,7 @@
       <div class="fixed-title-width flex items-center gap-2">
         {{ 'gateway.type' | translate }}
         <div  matSuffix
-              class="see-example"
+              class="see-example p-1"
               [tb-help-popup]="'widget/lib/gateway/report-strategy_fn'"
               tb-help-popup-placement="right"
               [tb-help-popup-style]="{maxWidth: '970px'}">

--- a/src/app/gateway/shared/models/gateway.models.ts
+++ b/src/app/gateway/shared/models/gateway.models.ts
@@ -23,10 +23,6 @@ import {
 } from '../../states/gateway-connectors/models/public-api';
 import { ConfigurationModes, ReportStrategyConfig } from './report-strategy.models';
 
-export const noLeadTrailSpacesRegex = /^\S+(?: \S+)*$/;
-export const integerRegex = /^[-+]?\d+$/;
-export const nonZeroFloat = /^-?(?!0(\.0+)?$)\d+(\.\d+)?$/;
-
 export const jsonRequired = (control: AbstractControl): ValidationErrors | null => !control.value ? {required: true} : null;
 
 export enum GatewayLogLevel {
@@ -150,4 +146,16 @@ export interface GatewayConfigCommand {
   command: string;
   timeout: number;
   installCmd?: string;
+}
+
+export enum HTTPMethods {
+  CONNECT = 'CONNECT',
+  DELETE = 'DELETE',
+  GET = 'GET',
+  HEAD = 'HEAD',
+  OPTIONS = 'OPTIONS',
+  PATCH = 'PATCH',
+  POST = 'POST',
+  PUT = 'PUT',
+  TRACE = 'TRACE'
 }

--- a/src/app/gateway/shared/models/public-api.ts
+++ b/src/app/gateway/shared/models/public-api.ts
@@ -20,3 +20,4 @@ export * from './connectors-default-config.constant';
 export * from './modbus.models';
 export * from './mapping.models';
 export * from './report-strategy.models';
+export * from './regex.models';

--- a/src/app/gateway/shared/models/regex.models.ts
+++ b/src/app/gateway/shared/models/regex.models.ts
@@ -13,11 +13,11 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 ///
-export * from './application-config/bacnet-application-config.component';
-export * from './device-data-keys-pannel/bacnet-device-data-keys-panel.component';
-export * from './basic-config/bacnet-basic-config.component';
-export * from './basic-config/bacnet-legacy-basic-config.component';
-export * from './device-data-key/bacnet-device-data-key.component';
-export * from './device-dialog/bacnet-device-dialog.component';
-export * from './devices-config-table/bacnet-devices-config-table.component';
 
+export const numberInputPattern = new RegExp(/^\d{1,15}(\.\d{1,15})?$/);
+
+export const noLeadTrailSpacesRegex = /^\S+(?: \S+)*$/;
+
+export const integerRegex = /^[-+]?\d+$/;
+
+export const nonZeroFloat = /^-?(?!0(\.0+)?$)\d+(\.\d+)?$/;

--- a/src/app/gateway/states/gateway-configuration/components/basic/gateway-basic-configuration.component.ts
+++ b/src/app/gateway/states/gateway-configuration/components/basic/gateway-basic-configuration.component.ts
@@ -50,6 +50,7 @@ import { take, takeUntil } from 'rxjs/operators';
 import {
   GatewayConfigCommand,
   noLeadTrailSpacesRegex,
+  numberInputPattern,
   ReportStrategyComponent,
   ReportStrategyDefaultValue,
   ReportStrategyType
@@ -59,7 +60,6 @@ import {
   GatewayBasicConfigTab,
   GatewayBasicConfigTabKey,
   GatewayConfigValue,
-  numberInputPattern,
 } from '../../models/public-api';
 import { MatTabGroup } from '@angular/material/tabs';
 import { GatewayStorageConfigurationComponent } from './storage/gateway-storage-configuration.component';

--- a/src/app/gateway/states/gateway-configuration/components/basic/grpc/gateway-grpc-configuration.component.ts
+++ b/src/app/gateway/states/gateway-configuration/components/basic/grpc/gateway-grpc-configuration.component.ts
@@ -25,11 +25,9 @@ import {
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '@shared/public-api';
-import {
-  GatewayGRPCConfig,
-  numberInputPattern,
-} from '../../../models/public-api';
+import { GatewayGRPCConfig } from '../../../models/public-api';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { numberInputPattern } from '../../../../../shared/models/public-api';
 
 @Component({
   selector: 'tb-gateway-grpc-configuration',

--- a/src/app/gateway/states/gateway-configuration/components/basic/storage/gateway-storage-configuration.component.ts
+++ b/src/app/gateway/states/gateway-configuration/components/basic/storage/gateway-storage-configuration.component.ts
@@ -27,11 +27,11 @@ import { CommonModule } from '@angular/common';
 import { SharedModule } from '@shared/public-api';
 import {
   GatewayStorageConfig,
-  numberInputPattern,
   StorageTypes,
   StorageTypesTranslationMap
 } from '../../../models/public-api';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { numberInputPattern } from '../../../../../shared/models/public-api';
 
 @Component({
   selector: 'tb-gateway-storage-configuration',

--- a/src/app/gateway/states/gateway-configuration/models/gateway-configuration.models.ts
+++ b/src/app/gateway/states/gateway-configuration/models/gateway-configuration.models.ts
@@ -236,8 +236,6 @@ export const SecurityTypesTranslationsMap = new Map<SecurityTypes, string>(
   ]
 );
 
-export const numberInputPattern = new RegExp(/^\d{1,15}$/);
-
 export const logsHandlerClass = 'thingsboard_gateway.tb_utility.tb_rotating_file_handler.TimedRotatingFileHandler';
 
 export const logsLegacyHandlerClass = 'thingsboard_gateway.tb_utility.tb_handler.TimedRotatingFileHandler';

--- a/src/app/gateway/states/gateway-connectors/components/bacnet/device-data-key/bacnet-device-data-key.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/bacnet/device-data-key/bacnet-device-data-key.component.html
@@ -106,7 +106,7 @@
             <mat-icon matSuffix
                       matTooltipPosition="above"
                       matTooltipClass="tb-error-tooltip"
-                      [matTooltip]="('gateway.object-id-required') | translate"
+                      [matTooltip]="('gateway.hints.object-id-required') | translate"
                       class="tb-error">
               warning
             </mat-icon>

--- a/src/app/gateway/states/gateway-connectors/components/bacnet/device-data-keys-pannel/bacnet-device-data-keys-panel.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/bacnet/device-data-keys-pannel/bacnet-device-data-keys-panel.component.scss
@@ -44,12 +44,6 @@
       font-size: 16px;
       padding-right: 0;
     }
-
-    .see-example {
-      width: 32px;
-      height: 32px;
-      margin: 4px;
-    }
   }
 }
 

--- a/src/app/gateway/states/gateway-connectors/components/bacnet/device-dialog/bacnet-device-dialog.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/bacnet/device-dialog/bacnet-device-dialog.component.scss
@@ -78,12 +78,6 @@
     }
   }
 
-  .see-example {
-    width: 32px;
-    height: 32px;
-    margin: 4px;
-  }
-
   .mat-mdc-form-field-icon-suffix {
     display: flex;
   }

--- a/src/app/gateway/states/gateway-connectors/components/device-info-table/device-info-table.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/device-info-table/device-info-table.component.html
@@ -51,7 +51,7 @@
             </mat-icon>
             <div *ngIf="connectorType | getConnectorMappingHelpLink : 'name-field' : mappingFormGroup.get('deviceNameExpressionSource').value : convertorType"
                  matSuffix
-                 class="see-example"
+                 class="see-example p-1"
                  [tb-help-popup]="connectorType | getConnectorMappingHelpLink : 'name-field' : mappingFormGroup.get('deviceNameExpressionSource').value : convertorType"
                  tb-help-popup-placement="left"
                  [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -85,7 +85,7 @@
             </mat-icon>
             <div *ngIf="connectorType | getConnectorMappingHelpLink: 'profile-name' : mappingFormGroup.get('deviceProfileExpressionSource').value : convertorType"
                  matSuffix
-                 class="see-example"
+                 class="see-example p-1"
                  [tb-help-popup]="connectorType | getConnectorMappingHelpLink:'profile-name' : mappingFormGroup.get('deviceProfileExpressionSource').value : convertorType"
                  tb-help-popup-placement="left"
                  [tb-help-popup-style]="{maxWidth: '970px'}">

--- a/src/app/gateway/states/gateway-connectors/components/device-info-table/device-info-table.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/device-info-table/device-info-table.component.ts
@@ -47,7 +47,7 @@ import {
   MQTTSourceType,
   SourceTypeTranslationsMap,
   SourceType,
-  ConvertorType
+  ConverterType
 } from '../../models/public-api';
 import { coerceBoolean, PageComponent, SharedModule } from '@shared/public-api';
 import { CommonModule } from '@angular/common';
@@ -93,7 +93,7 @@ export class DeviceInfoTableComponent extends PageComponent implements ControlVa
 
   @Input() connectorType: ConnectorType = ConnectorType.MQTT;
 
-  @Input() convertorType: ConvertorType;
+  @Input() convertorType: ConverterType;
 
   @Input()
   sourceTypes: Array<SourceType> = Object.values(MQTTSourceType) as Array<SourceType>;

--- a/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.html
@@ -55,8 +55,8 @@
                           warning
                         </mat-icon>
                         <div matSuffix
-                             class="see-example"
-                             *ngIf="connectorType === ConnectorType.MQTT && connectorType | getConnectorMappingHelpLink : this.keysType : keyControl.get('type').value : convertorType"
+                             class="see-example p-1"
+                             *ngIf="connectorType | getConnectorMappingHelpLink : this.keysType : keyControl.get('type').value : convertorType"
                              [tb-help-popup]="connectorType | getConnectorMappingHelpLink : this.keysType : keyControl.get('type').value : convertorType"
                              tb-help-popup-placement="left"
                              [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -119,7 +119,7 @@
                           warning
                         </mat-icon>
                         <div matSuffix
-                             class="see-example"
+                             class="see-example p-1"
                              *ngIf="connectorType | getConnectorMappingHelpLink : this.keysType : keyControl.get('type').value : convertorType"
                              [tb-help-popup]="connectorType | getConnectorMappingHelpLink : this.keysType : keyControl.get('type').value : convertorType"
                              tb-help-popup-placement="left"

--- a/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.scss
@@ -43,12 +43,6 @@
         color: rgba(0, 0, 0, 0.54);
       }
     }
-
-    .see-example {
-      width: 32px;
-      height: 32px;
-      margin: 4px;
-    }
   }
 }
 

--- a/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-data-keys-panel/mapping-data-keys-panel.component.ts
@@ -23,10 +23,10 @@ import {
 } from '@angular/core';
 import {
   AbstractControl,
+  FormArray,
   FormControl,
   FormGroup,
-  UntypedFormArray,
-  UntypedFormBuilder,
+  FormBuilder,
   Validators
 } from '@angular/forms';
 import { coerceBoolean, SharedModule } from '@shared/public-api';
@@ -35,7 +35,7 @@ import { Store } from '@ngrx/store';
 import { PageComponent } from '@shared/public-api';
 import { isDefinedAndNotNull, AppState } from '@core/public-api';
 import {
-  ConvertorType,
+  MqttConverterType,
   MappingDataKey,
   MappingKeysType,
   OPCUaSourceType,
@@ -76,7 +76,7 @@ export class MappingDataKeysPanelComponent extends PageComponent implements OnIn
   @Input() keys: Array<MappingDataKey> | {[key: string]: any};
   @Input() keysType: MappingKeysType;
   @Input() connectorType: ConnectorType;
-  @Input() convertorType: ConvertorType;
+  @Input() convertorType: MqttConverterType;
   @Input() sourceType: SourceType;
   @Input() valueTypeEnum = MappingValueType;
   @Input() valueTypes: Map<string, unknown> = mappingValueTypesMap;
@@ -91,11 +91,11 @@ export class MappingDataKeysPanelComponent extends PageComponent implements OnIn
   readonly ReportStrategyDefaultValue = ReportStrategyDefaultValue;
   readonly ConnectorType = ConnectorType;
 
-  keysListFormArray: UntypedFormArray;
+  keysListFormArray: FormArray;
 
   errorText = '';
 
-  constructor(private fb: UntypedFormBuilder,
+  constructor(private fb: FormBuilder,
               protected store: Store<AppState>) {
     super(store);
   }
@@ -157,7 +157,7 @@ export class MappingDataKeysPanelComponent extends PageComponent implements OnIn
     this.keysDataApplied.emit(keys);
   }
 
-  private prepareKeysFormArray(keys: Array<MappingDataKey | RpcMethodsMapping> | {[key: string]: any}): UntypedFormArray {
+  private prepareKeysFormArray(keys: Array<MappingDataKey | RpcMethodsMapping> | {[key: string]: any}): FormArray {
     const keysControlGroups: Array<AbstractControl> = [];
     if (keys) {
       if (this.keysType === MappingKeysType.CUSTOM) {

--- a/src/app/gateway/states/gateway-connectors/components/mapping-dialog/mapping-dialog.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-dialog/mapping-dialog.component.html
@@ -46,7 +46,7 @@
                   warning
                 </mat-icon>
                 <div matSuffix
-                     class="see-example"
+                     class="see-example p-1"
                      [tb-help-popup]="'widget/lib/gateway/topic-filter_fn'"
                      tb-help-popup-placement="left"
                      [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -217,7 +217,7 @@
                         warning
                       </mat-icon>
                       <div matSuffix
-                           class="see-example"
+                           class="see-example p-1"
                            [tb-help-popup]="'widget/lib/gateway/topic-filter_fn'"
                            tb-help-popup-placement="left"
                            [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -262,7 +262,7 @@
                               warning
                             </mat-icon>
                             <div matSuffix
-                                 class="see-example"
+                                 class="see-example p-1"
                                  [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                                  tb-help-popup-placement="left"
                                  [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -292,7 +292,7 @@
                             warning
                           </mat-icon>
                           <div matSuffix
-                               class="see-example"
+                               class="see-example p-1"
                                [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                                tb-help-popup-placement="left"
                                [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -320,7 +320,7 @@
                             warning
                           </mat-icon>
                           <div matSuffix
-                               class="see-example"
+                               class="see-example p-1"
                                [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                                tb-help-popup-placement="left"
                                [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -341,7 +341,7 @@
                             warning
                           </mat-icon>
                           <div matSuffix
-                               class="see-example"
+                               class="see-example p-1"
                                [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                                tb-help-popup-placement="left"
                                [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -407,7 +407,7 @@
                           warning
                         </mat-icon>
                         <div matSuffix
-                             class="see-example"
+                             class="see-example p-1"
                              [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                              tb-help-popup-placement="left"
                              [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -428,7 +428,7 @@
                           warning
                         </mat-icon>
                         <div matSuffix
-                             class="see-example"
+                             class="see-example p-1"
                              [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                              tb-help-popup-placement="left"
                              [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -502,7 +502,7 @@
                           warning
                         </mat-icon>
                         <div matSuffix
-                             class="see-example"
+                             class="see-example p-1"
                              [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                              tb-help-popup-placement="left"
                              [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -523,7 +523,7 @@
                           warning
                         </mat-icon>
                         <div matSuffix
-                             class="see-example"
+                             class="see-example p-1"
                              [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                              tb-help-popup-placement="left"
                              [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -545,7 +545,7 @@
                             warning
                           </mat-icon>
                           <div matSuffix
-                               class="see-example"
+                               class="see-example p-1"
                                [tb-help-popup]="'widget/lib/gateway/expressions_fn'"
                                tb-help-popup-placement="left"
                                [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -569,16 +569,13 @@
                         <mat-form-field class="tb-flex" appearance="outline" subscriptSizing="dynamic">
                           <input matInput name="value" type="number" min="1" formControlName="responseTimeout"
                                  placeholder="{{ 'gateway.set' | translate }}"/>
-                          <mat-icon matSuffix
-                                    matTooltipPosition="above"
-                                    matTooltipClass="tb-error-tooltip"
-                                    [matTooltip]="responseTimeoutErrorTooltip"
-                                    *ngIf="(mappingForm.get('requestValue.serverSideRpc.responseTimeout').hasError('required') ||
-                                            mappingForm.get('requestValue.serverSideRpc.responseTimeout').hasError('min')) &&
-                                            mappingForm.get('requestValue.serverSideRpc.responseTimeout').touched"
-                                    class="tb-error">
-                            warning
-                          </mat-icon>
+                          @if ((mappingForm.get('requestValue.serverSideRpc.responseTimeout').hasError('required')
+                            || mappingForm.get('requestValue.serverSideRpc.responseTimeout').hasError('min'))
+                          && mappingForm.get('requestValue.serverSideRpc.responseTimeout').touched) {
+                            <tb-error-icon matSuffix [tooltipText]="responseTimeoutErrorTooltip"/>
+                          } @else {
+                            <span translate class="block pr-2" matSuffix>gateway.suffix.ms</span>
+                          }
                         </mat-form-field>
                     </div>
                   </ng-container>
@@ -613,7 +610,7 @@
                   warning
                 </mat-icon>
                 <div matSuffix
-                     class="see-example"
+                     class="see-example p-1"
                      [tb-help-popup]="ConnectorType.OPCUA | getConnectorMappingHelpLink: 'device-node' : mappingForm.get('deviceNodeSource').value"
                      tb-help-popup-placement="left"
                      [tb-help-popup-style]="{maxWidth: '970px'}">

--- a/src/app/gateway/states/gateway-connectors/components/mapping-dialog/mapping-dialog.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-dialog/mapping-dialog.component.scss
@@ -64,12 +64,6 @@
     }
   }
 
-  .see-example {
-    width: 32px;
-    height: 32px;
-    margin: 4px;
-  }
-
   .mat-mdc-form-field-icon-suffix {
     display: flex;
   }

--- a/src/app/gateway/states/gateway-connectors/components/mapping-dialog/mapping-dialog.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-dialog/mapping-dialog.component.ts
@@ -26,7 +26,7 @@ import {
   ConnectorMapping,
   ConnectorMappingFormValue,
   ConverterMappingFormValue,
-  ConvertorType,
+  MqttConverterType,
   ConvertorTypeTranslationsMap,
   DataConversionTranslationsMap,
   DeviceConnectorMapping,
@@ -64,6 +64,7 @@ import { EllipsisChipListDirective } from '../../../../shared/directives/public-
 import { ConnectorMappingHelpLinkPipe } from '../../pipes/public-api';
 import { DeviceInfoTableComponent } from '../device-info-table/device-info-table.component';
 import { MappingDataKeysPanelComponent } from '../mapping-data-keys-panel/mapping-data-keys-panel.component';
+import { ErrorTooltipIconComponent } from '../../../../shared/components/error-icon/error-icon.component';
 
 @Component({
   selector: 'tb-mapping-dialog',
@@ -76,6 +77,7 @@ import { MappingDataKeysPanelComponent } from '../mapping-data-keys-panel/mappin
     ConnectorMappingHelpLinkPipe,
     EllipsisChipListDirective,
     DeviceInfoTableComponent,
+    ErrorTooltipIconComponent,
   ]
 })
 export class MappingDialogComponent extends DialogComponent<MappingDialogComponent, ConnectorMapping> implements OnDestroy {
@@ -85,8 +87,8 @@ export class MappingDialogComponent extends DialogComponent<MappingDialogCompone
   readonly MappingType = MappingType;
   readonly qualityTypes = QualityTypes;
   readonly QualityTranslationsMap = QualityTypeTranslationsMap;
-  readonly convertorTypes: ConvertorType[] = Object.values(ConvertorType) as ConvertorType[];
-  readonly ConvertorTypeEnum = ConvertorType;
+  readonly convertorTypes: MqttConverterType[] = Object.values(MqttConverterType) as MqttConverterType[];
+  readonly ConvertorTypeEnum = MqttConverterType;
   readonly ConvertorTypeTranslationsMap = ConvertorTypeTranslationsMap;
   readonly sourceTypes: SourceType[] = Object.values(MQTTSourceType) as MQTTSourceType[];
   readonly OPCUaSourceTypes = Object.values(OPCUaSourceType) as Array<OPCUaSourceType>;
@@ -151,7 +153,7 @@ export class MappingDialogComponent extends DialogComponent<MappingDialogCompone
     return this.mappingForm.get('attributes_updates')?.value?.map((value: AttributesUpdate) => value.key) || [];
   }
 
-  get converterType(): ConvertorType {
+  get converterType(): MqttConverterType {
     return this.mappingForm.get('converter')?.get('type').value;
   }
 
@@ -222,7 +224,7 @@ export class MappingDialogComponent extends DialogComponent<MappingDialogCompone
       const ctx: { [key: string]: any } = {
         keys: keysControl.value,
         keysType,
-        rawData: this.mappingForm.get('converter.type')?.value === ConvertorType.BYTES,
+        rawData: this.mappingForm.get('converter.type')?.value === MqttConverterType.BYTES,
         panelTitle: MappingKeysPanelTitleTranslationsMap.get(keysType),
         addKeyTitle: MappingKeysAddKeyTranslationsMap.get(keysType),
         deleteKeyTitle: MappingKeysDeleteKeyTranslationsMap.get(keysType),
@@ -309,7 +311,7 @@ export class MappingDialogComponent extends DialogComponent<MappingDialogCompone
       this.fb.control('', [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]));
     this.mappingForm.addControl('subscriptionQos', this.fb.control(0));
     this.mappingForm.addControl('converter', this.fb.group({
-      type: [ConvertorType.JSON, []],
+      type: [MqttConverterType.JSON, []],
       json: this.fb.group({
         deviceInfo: [{}, []],
         attributes: [[], []],

--- a/src/app/gateway/states/gateway-connectors/components/mapping-table/mapping-table.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/mapping-table/mapping-table.component.ts
@@ -59,7 +59,6 @@ import { TruncateWithTooltipDirective } from '../../../../shared/directives/publ
 import { MappingDialogComponent } from '../public-api';
 import { isDefinedAndNotNull, isUndefinedOrNull, DialogService } from '@core/public-api';
 import { CommonModule } from '@angular/common';
-// @ts-ignore
 import { TbTableDatasource, coerceBoolean, SharedModule } from '@shared/public-api';
 
 @Component({
@@ -80,7 +79,7 @@ import { TbTableDatasource, coerceBoolean, SharedModule } from '@shared/public-a
     }
   ],
   standalone: true,
-  imports: [CommonModule, SharedModule, TruncateWithTooltipDirective, MappingDialogComponent]
+  imports: [CommonModule, SharedModule, TruncateWithTooltipDirective]
 })
 export class MappingTableComponent implements ControlValueAccessor, Validator, AfterViewInit, OnInit, OnDestroy {
 
@@ -230,7 +229,6 @@ export class MappingTableComponent implements ControlValueAccessor, Validator, A
         )
       );
     }
-    // @ts-ignore
     this.dataSource.loadData(tableValue);
   }
 

--- a/src/app/gateway/states/gateway-connectors/components/modbus/modbus-data-keys-panel/modbus-data-keys-panel.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/modbus/modbus-data-keys-panel/modbus-data-keys-panel.component.html
@@ -46,7 +46,7 @@
                 <div class="tb-form-hint tb-primary-fill tb-flex align-center">
                   {{ 'gateway.hints.modbus.data-keys' | translate }}
                   <div matSuffix
-                       class="see-example"
+                       class="see-example p-1"
                        [tb-help-popup]="'widget/lib/gateway/modbus-functions-data-types_fn'"
                        tb-help-popup-placement="left"
                        [tb-help-popup-style]="{maxWidth: '970px'}">

--- a/src/app/gateway/states/gateway-connectors/components/modbus/modbus-master-table/modbus-master-table.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/modbus/modbus-master-table/modbus-master-table.component.ts
@@ -50,7 +50,6 @@ import { isDefinedAndNotNull, DialogService } from '@core/public-api';
 import { CommonModule } from '@angular/common';
 import { ModbusSlaveDialogComponent } from '../modbus-slave-dialog/modbus-slave-dialog.component';
 import {
-  // @ts-ignore
   TbTableDatasource,
   SharedModule
 } from '@shared/public-api';

--- a/src/app/gateway/states/gateway-connectors/components/mqtt/basic-config/mqtt-basic-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/mqtt/basic-config/mqtt-basic-config.component.ts
@@ -30,9 +30,6 @@ import {
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '@shared/public-api';
 import {
-  SecurityConfigComponent
-} from '../../security-config/security-config.component';
-import {
   WorkersConfigControlComponent
 } from '../workers-config-control/workers-config-control.component';
 import {
@@ -63,7 +60,6 @@ import {
   imports: [
     CommonModule,
     SharedModule,
-    SecurityConfigComponent,
     WorkersConfigControlComponent,
     BrokerConfigControlComponent,
     MappingTableComponent,

--- a/src/app/gateway/states/gateway-connectors/components/mqtt/basic-config/mqtt-legacy-basic-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/mqtt/basic-config/mqtt-legacy-basic-config.component.ts
@@ -31,9 +31,6 @@ import {
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '@shared/public-api';
 import {
-  SecurityConfigComponent
-} from '../../security-config/security-config.component';
-import {
   WorkersConfigControlComponent
 } from '../workers-config-control/workers-config-control.component';
 import {
@@ -65,7 +62,6 @@ import { MqttVersionMappingUtil } from '../../../utils/public-api';
   imports: [
     CommonModule,
     SharedModule,
-    SecurityConfigComponent,
     WorkersConfigControlComponent,
     BrokerConfigControlComponent,
     MappingTableComponent,

--- a/src/app/gateway/states/gateway-connectors/components/opc/opc-server-config/opc-server-config.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/opc/opc-server-config/opc-server-config.component.html
@@ -35,16 +35,13 @@
     </div>
     <mat-form-field class="tb-flex no-gap" appearance="outline" subscriptSizing="dynamic">
       <input matInput type="number" min="1000" name="value" formControlName="timeoutInMillis" placeholder="{{ 'gateway.set' | translate }}"/>
-      <mat-icon matSuffix
-                matTooltipPosition="above"
-                matTooltipClass="tb-error-tooltip"
-                [matTooltip]="'gateway.timeout-error' | translate: {min: 1000}"
-                *ngIf="(serverConfigFormGroup.get('timeoutInMillis').hasError('required') ||
-                       serverConfigFormGroup.get('timeoutInMillis').hasError('min')) &&
-                       serverConfigFormGroup.get('timeoutInMillis').touched"
-                class="tb-error">
-        warning
-      </mat-icon>
+      @if ((serverConfigFormGroup.get('timeoutInMillis').hasError('required')
+        || serverConfigFormGroup.get('timeoutInMillis').hasError('min'))
+      && serverConfigFormGroup.get('timeoutInMillis').touched) {
+        <tb-error-icon matSuffix [tooltipText]="'gateway.timeout-error' | translate: {min: 1000}"/>
+      } @else {
+        <span translate class="block pr-2" matSuffix>gateway.suffix.ms</span>
+      }
     </mat-form-field>
   </div>
   <div class="tb-form-row column-xs">
@@ -128,7 +125,5 @@
       </mat-label>
     </mat-slide-toggle>
   </div>
-  <tb-security-config formControlName="identity"
-                      [extendCertificatesModel]="true">
-  </tb-security-config>
+  <tb-security-config formControlName="identity" [mode]="SecurityMode.extendedCertificates"/>
 </div>

--- a/src/app/gateway/states/gateway-connectors/components/opc/opc-server-config/opc-server-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/opc/opc-server-config/opc-server-config.component.ts
@@ -26,11 +26,13 @@ import {
   Validators
 } from '@angular/forms';
 import {
+  SecurityMode,
   SecurityPolicy,
   SecurityPolicyTypes,
   ServerConfig,
 } from '../../../models/public-api';
 import {
+  ErrorTooltipIconComponent,
   noLeadTrailSpacesRegex,
   TruncateWithTooltipDirective
 } from '../../../../../shared/public-api';
@@ -65,6 +67,7 @@ import {
     SharedModule,
     SecurityConfigComponent,
     TruncateWithTooltipDirective,
+    ErrorTooltipIconComponent,
   ]
 })
 export class OpcServerConfigComponent implements ControlValueAccessor, Validator, AfterViewInit, OnDestroy {
@@ -74,6 +77,7 @@ export class OpcServerConfigComponent implements ControlValueAccessor, Validator
   hideNewFields: boolean = false;
 
   securityPolicyTypes = SecurityPolicyTypes;
+  SecurityMode = SecurityMode;
   serverConfigFormGroup: UntypedFormGroup;
 
   onChange!: (value: ServerConfig) => void;

--- a/src/app/gateway/states/gateway-connectors/components/security-config/security-config.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/security-config/security-config.component.html
@@ -25,7 +25,7 @@
   <ng-container [ngSwitch]="securityFormGroup.get('type').value">
     <ng-template [ngSwitchCase]="BrokerSecurityType.BASIC">
       <div class="tb-form-row space-between tb-flex fill-width">
-        <div class="fixed-title-width" translate>gateway.username</div>
+        <div class="fixed-title-width tb-required" translate>gateway.username</div>
         <div class="tb-flex no-gap">
           <mat-form-field class="tb-flex no-gap" appearance="outline" subscriptSizing="dynamic">
             <input matInput name="value" formControlName="username" placeholder="{{ 'gateway.set' | translate }}"/>
@@ -79,7 +79,7 @@
           </mat-form-field>
         </div>
       </div>
-      <ng-container *ngIf="extendCertificatesModel">
+      <ng-container *ngIf="mode() === SecurityMode.extendedCertificates">
         <div class="tb-form-row space-between tb-flex fill-width">
           <div class="fixed-title-width" translate>gateway.mode</div>
           <div class="tb-flex no-gap">

--- a/src/app/gateway/states/gateway-connectors/components/socket/device-data-keys-pannel/device-data-keys-panel.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/socket/device-data-keys-pannel/device-data-keys-panel.component.html
@@ -75,7 +75,7 @@
                       <div class="fixed-title-width tb-flex align-center">
                         <span class="tb-required">{{ 'gateway.byte' | translate }}</span>
                         <div  matSuffix
-                              class="see-example"
+                              class="see-example p-1"
                               [tb-help-popup]="'widget/lib/gateway/byte_fn'"
                               tb-help-popup-placement="left"
                               [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -200,7 +200,7 @@
                         </mat-icon>
                         <div  matSuffix
                               *ngIf="keyControl.get('requestExpressionSource').value === ExpressionType.Expression"
-                              class="see-example"
+                              class="see-example p-1"
                               [tb-help-popup]="'widget/lib/gateway/request-expression_fn'"
                               tb-help-popup-placement="left"
                               [tb-help-popup-style]="{maxWidth: '970px'}">
@@ -232,7 +232,7 @@
                         </mat-icon>
                         <div  matSuffix
                               *ngIf="keyControl.get('attributeNameExpressionSource').value === ExpressionType.Expression"
-                              class="see-example"
+                              class="see-example p-1"
                               [tb-help-popup]="'widget/lib/gateway/attribute-name-expression_fn'"
                               tb-help-popup-placement="left"
                               [tb-help-popup-style]="{maxWidth: '970px'}">

--- a/src/app/gateway/states/gateway-connectors/components/socket/device-data-keys-pannel/device-data-keys-panel.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/socket/device-data-keys-pannel/device-data-keys-panel.component.scss
@@ -44,12 +44,6 @@
       font-size: 16px;
       padding-right: 0;
     }
-
-    .see-example {
-      width: 32px;
-      height: 32px;
-      margin: 4px;
-    }
   }
 }
 

--- a/src/app/gateway/states/gateway-connectors/components/socket/device-dialog/device-dialog.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/socket/device-dialog/device-dialog.component.html
@@ -47,7 +47,7 @@
               warning
             </mat-icon>
             <div  matSuffix
-                  class="see-example"
+                  class="see-example p-1"
                   [tb-help-popup]="'widget/lib/gateway/address-filter_fn'"
                   tb-help-popup-placement="left"
                   [tb-help-popup-style]="{maxWidth: '970px'}">

--- a/src/app/gateway/states/gateway-connectors/components/socket/device-dialog/device-dialog.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/socket/device-dialog/device-dialog.component.scss
@@ -69,12 +69,6 @@
     }
   }
 
-  .see-example {
-    width: 32px;
-    height: 32px;
-    margin: 4px;
-  }
-
   .mat-mdc-form-field-icon-suffix {
     display: flex;
   }

--- a/src/app/gateway/states/gateway-connectors/components/socket/devices-config-table/devices-config-table.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/socket/devices-config-table/devices-config-table.component.ts
@@ -43,7 +43,6 @@ import { TruncateWithTooltipDirective } from '../../../../../shared/directives/p
 import { isDefinedAndNotNull, DialogService } from '@core/public-api';
 import { CommonModule } from '@angular/common';
 import {
-  // @ts-ignore
   TbTableDatasource,
   SharedModule,
   coerceBoolean

--- a/src/app/gateway/states/gateway-connectors/components/type-value-field/type-value-field.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/type-value-field/type-value-field.component.html
@@ -68,7 +68,7 @@
         warning
       </mat-icon>
       <div matSuffix
-           class="see-example"
+           class="see-example p-1"
            *ngIf="helpLink"
            (click)="$event.stopPropagation()"
            [tb-help-popup]="helpLink"

--- a/src/app/gateway/states/gateway-connectors/components/type-value-panel/type-value-panel.component.scss
+++ b/src/app/gateway/states/gateway-connectors/components/type-value-panel/type-value-panel.component.scss
@@ -33,12 +33,6 @@
       color: rgba(0, 0, 0, 0.54);
     }
   }
-
-  .see-example {
-    width: 32px;
-    height: 32px;
-    margin: 4px;
-  }
 }
 
 :host ::ng-deep {

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.html
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.html
@@ -178,7 +178,7 @@
               *ngIf="connectorForm.get('configVersion').value | isLatestVersionConfig : ConnectorType.MQTT else legacy"
               formControlName="basicConfig"
               [generalTabContent]="generalTabContent"
-              [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy : ConnectorType.MQTT"
+              [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy"
               (initialized)="basicConfigInitSubject.next()"
             />
             <ng-template #legacy>
@@ -186,7 +186,7 @@
                 (initialized)="basicConfigInitSubject.next()"
                 formControlName="basicConfig"
                 [generalTabContent]="generalTabContent"
-                [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy : ConnectorType.MQTT"
+                [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy"
               />
             </ng-template>
           </ng-container>
@@ -195,7 +195,7 @@
               *ngIf="connectorForm.get('configVersion').value | isLatestVersionConfig : ConnectorType.OPCUA else legacy"
               formControlName="basicConfig"
               [generalTabContent]="generalTabContent"
-              [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy : ConnectorType.OPCUA"
+              [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy"
               (initialized)="basicConfigInitSubject.next()"
             />
             <ng-template #legacy>
@@ -203,7 +203,7 @@
                 (initialized)="basicConfigInitSubject.next()"
                 formControlName="basicConfig"
                 [generalTabContent]="generalTabContent"
-                [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy : ConnectorType.OPCUA"
+                [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy"
               />
             </ng-template>
           </ng-container>
@@ -243,7 +243,7 @@
               formControlName="basicConfig"
               [generalTabContent]="generalTabContent"
               (initialized)="basicConfigInitSubject.next()"
-              [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy : ConnectorType.BACNET"
+              [withReportStrategy]="connectorForm.get('configVersion').value | withReportStrategy"
             />
             <ng-template #legacy>
               <tb-bacnet-legacy-basic-config

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.ts
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.ts
@@ -78,14 +78,11 @@ import {
 import { AttributeDatasource, } from '../../shared/datasources/public-api';
 import { GatewayConnectorVersionMappingUtil } from './utils/public-api';
 import { ReportStrategyVersionPipe } from '../../shared/pipes/public-api';
-import { ConnectorBaseInfo, AddConnectorConfigData, GatewayAttributeData } from './models/public-api';
+import { AddConnectorConfigData, ConnectorBaseInfo, GatewayAttributeData } from './models/public-api';
 import { CommonModule } from '@angular/common';
 import { LatestVersionConfigPipe } from './pipes/public-api';
 import { ReportStrategyComponent } from '../../shared/components/public-api';
-import { BacnetBasicConfigComponent } from './components/bacnet/basic-config/bacnet-basic-config.component';
-import {
-  BacnetLegacyBasicConfigComponent
-} from './components/bacnet/basic-config/bacnet-legacy-basic-config.component';
+import { BacnetBasicConfigComponent, BacnetLegacyBasicConfigComponent } from './components/bacnet/public-api';
 
 export class ForceErrorStateMatcher implements ErrorStateMatcher {
   isErrorState(control: FormControl | null): boolean {
@@ -114,7 +111,7 @@ export class ForceErrorStateMatcher implements ErrorStateMatcher {
     SocketLegacyBasicConfigComponent,
     ReportStrategyComponent,
     BacnetBasicConfigComponent,
-    BacnetLegacyBasicConfigComponent
+    BacnetLegacyBasicConfigComponent,
   ],
 })
 export class GatewayConnectorComponent extends PageComponent implements AfterViewInit, OnDestroy {

--- a/src/app/gateway/states/gateway-connectors/models/connectors.model.ts
+++ b/src/app/gateway/states/gateway-connectors/models/connectors.model.ts
@@ -32,7 +32,8 @@ import {
   RequestMappingFormValue,
   RequestMappingValue,
   RequestsMapping,
-  MQTTSourceType
+  MQTTSourceType,
+  MqttConverterType
 } from './mqtt.models';
 import { DeviceConnectorMapping, OPCBasicConfig_v3_5_2, OPCLegacyBasicConfig, OpcUaMapping } from './opc.models';
 import { ModbusBasicConfig_v3_5_2, ModbusLegacyBasicConfig } from './modbus.models';
@@ -332,5 +333,13 @@ export interface DeviceConfigInfo {
   buttonTitle: string;
   withReportStrategy?: boolean;
 }
+
+export enum SecurityMode {
+  basic = 'basic',
+  certificates = 'certificates',
+  extendedCertificates = 'extendedCertificates'
+}
+
+export type ConverterType = MqttConverterType;
 
 

--- a/src/app/gateway/states/gateway-connectors/models/mqtt.models.ts
+++ b/src/app/gateway/states/gateway-connectors/models/mqtt.models.ts
@@ -39,7 +39,7 @@ export interface DataMapping {
 }
 
 export interface Converter {
-  type: ConvertorType;
+  type: MqttConverterType;
   deviceInfo?: ConnectorDeviceInfo;
   sendDataOnlyOnChange: boolean;
   timeout: number;
@@ -50,7 +50,7 @@ export interface Converter {
   extensionConfig?: Record<string, number>;
 }
 
-export enum ConvertorType {
+export enum MqttConverterType {
   JSON = 'json',
   BYTES = 'bytes',
   CUSTOM = 'custom'
@@ -102,11 +102,11 @@ export interface ConverterConnectorMapping {
   converter: Converter;
 }
 
-export const ConvertorTypeTranslationsMap = new Map<ConvertorType, string>(
+export const ConvertorTypeTranslationsMap = new Map<MqttConverterType, string>(
   [
-    [ConvertorType.JSON, 'gateway.JSON'],
-    [ConvertorType.BYTES, 'gateway.bytes'],
-    [ConvertorType.CUSTOM, 'gateway.custom']
+    [MqttConverterType.JSON, 'gateway.JSON'],
+    [MqttConverterType.BYTES, 'gateway.bytes'],
+    [MqttConverterType.CUSTOM, 'gateway.custom']
   ]
 );
 
@@ -240,14 +240,14 @@ export const RequestTypesTranslationsMap = new Map<RequestType, string>(
 
 export type ConverterMappingFormValue = Omit<ConverterConnectorMapping, 'converter'> & {
   converter: {
-    type: ConvertorType;
-  } & Record<ConvertorType, Converter>;
+    type: MqttConverterType;
+  } & Record<MqttConverterType, Converter>;
 };
 
-export const DataConversionTranslationsMap = new Map<ConvertorType, string>(
+export const DataConversionTranslationsMap = new Map<MqttConverterType, string>(
   [
-    [ConvertorType.JSON, 'gateway.JSON-hint'],
-    [ConvertorType.BYTES, 'gateway.bytes-hint'],
-    [ConvertorType.CUSTOM, 'gateway.custom-hint']
+    [MqttConverterType.JSON, 'gateway.JSON-hint'],
+    [MqttConverterType.BYTES, 'gateway.bytes-hint'],
+    [MqttConverterType.CUSTOM, 'gateway.custom-hint']
   ]
 );

--- a/src/app/gateway/states/gateway-connectors/pipes/gateway-help-link.pipe.ts
+++ b/src/app/gateway/states/gateway-connectors/pipes/gateway-help-link.pipe.ts
@@ -15,7 +15,14 @@
 ///
 
 import { Pipe, PipeTransform } from '@angular/core';
-import { ConvertorType, MappingKeysType, MQTTSourceType, OPCUaSourceType, SourceType } from '../models/public-api';
+import {
+  MappingKeysType,
+  MqttConverterType,
+  MQTTSourceType,
+  OPCUaSourceType,
+  SourceType,
+  ConverterType
+} from '../models/public-api';
 import { ConnectorType } from '../../../shared/models/public-api';
 
 @Pipe({
@@ -23,12 +30,12 @@ import { ConnectorType } from '../../../shared/models/public-api';
   standalone: true,
 })
 export class ConnectorMappingHelpLinkPipe implements PipeTransform {
-  transform(connectorType: ConnectorType, field: string, sourceType: SourceType, convertorType?: ConvertorType): string {
+  transform(connectorType: ConnectorType, field: string, sourceType: SourceType, converterType?: ConverterType): string {
     switch (connectorType) {
       case ConnectorType.OPCUA:
         return this.getOpcConnectorHelpLink(field, sourceType);
       case ConnectorType.MQTT:
-        return this.getMqttConnectorHelpLink(field, sourceType, convertorType);
+        return this.getMqttConnectorHelpLink(field, sourceType, converterType);
       case ConnectorType.BACNET:
         return this.getBacnetConnectorHelpLink(field, sourceType);
     }
@@ -41,14 +48,14 @@ export class ConnectorMappingHelpLinkPipe implements PipeTransform {
     return;
   }
 
-  private getMqttConnectorHelpLink(field: string, sourceType: SourceType, convertorType: ConvertorType): string {
+  private getMqttConnectorHelpLink(field: string, sourceType: SourceType, convertorType: MqttConverterType): string {
     if (sourceType === MQTTSourceType.CONST) {
       return;
     }
     if (!convertorType) {
       return `widget/lib/gateway/mqtt-expression_fn`;
     }
-    if ((field === MappingKeysType.ATTRIBUTES || field === MappingKeysType.TIMESERIES) && convertorType === ConvertorType.JSON) {
+    if ((field === MappingKeysType.ATTRIBUTES || field === MappingKeysType.TIMESERIES) && convertorType === MqttConverterType.JSON) {
       return 'widget/lib/gateway/mqtt-json-key-expression_fn';
     }
     return `widget/lib/gateway/mqtt-${convertorType}-expression_fn`;

--- a/src/app/gateway/states/gateway-connectors/utils/gateway-connector-version-mapping.util.ts
+++ b/src/app/gateway/states/gateway-connectors/utils/gateway-connector-version-mapping.util.ts
@@ -16,12 +16,14 @@
 
 import {
   BacnetBasicConfig,
+  ConnectorBaseInfo,
   ModbusBasicConfig,
   MQTTBasicConfig,
   OPCBasicConfig,
   SocketBasicConfig,
 } from '../models/public-api';
 import {
+  ConnectorBaseConfig,
   ConnectorType,
   GatewayConnector,
 } from '../../../shared/models/public-api';
@@ -30,7 +32,7 @@ import {
   OpcVersionProcessor,
   ModbusVersionProcessor,
   SocketVersionProcessor,
-  BacnetVersionProcessor
+  BacnetVersionProcessor,
 } from '../abstract/public-api';
 import { isNumber, isString } from '@core/public-api';
 
@@ -62,5 +64,10 @@ export abstract class GatewayConnectorVersionMappingUtil {
     }
 
     return 0;
+  }
+
+  static cleanUpConfigBaseInfo(config: ConnectorBaseConfig): ConnectorBaseConfig {
+    const { name, id, enableRemoteLogging, logLevel, reportStrategy, configVersion, ...restConfig } = config as ConnectorBaseInfo;
+    return restConfig as ConnectorBaseConfig;
   }
 }

--- a/src/app/gateway/states/gateway-connectors/utils/mqtt-version-mapping.util.ts
+++ b/src/app/gateway/states/gateway-connectors/utils/mqtt-version-mapping.util.ts
@@ -20,7 +20,7 @@ import {
   ConnectorDeviceInfo,
   Converter,
   ConverterConnectorMapping,
-  ConvertorType,
+  MqttConverterType,
   LegacyConverter,
   LegacyConverterConnectorMapping,
   LegacyRequestMappingData,
@@ -124,7 +124,7 @@ export class MqttVersionMappingUtil {
   private static mapConverterToDowngradedVersion(converter: Converter): LegacyConverter {
     const { deviceInfo, ...restConverter } = converter;
 
-    return converter.type !== ConvertorType.BYTES ? {
+    return converter.type !== MqttConverterType.BYTES ? {
       ...restConverter,
       deviceNameJsonExpression: deviceInfo?.deviceNameExpressionSource === MQTTSourceType.MSG ? deviceInfo.deviceNameExpression : null,
       deviceTypeJsonExpression:

--- a/src/app/gateway/states/gateway-connectors/utils/socket-version-mapping.util.ts
+++ b/src/app/gateway/states/gateway-connectors/utils/socket-version-mapping.util.ts
@@ -22,12 +22,13 @@ import {
   SocketConfig,
   SocketLegacyBasicConfig,
 } from '../models/public-api';
+import { GatewayConnectorVersionMappingUtil } from './gateway-connector-version-mapping.util';
 
 export class SocketVersionMappingUtil {
 
   static mapSocketToUpgradedVersion(config: SocketLegacyBasicConfig): SocketConfig {
-    const { devices, ...socket } = config ?? {} as SocketLegacyBasicConfig;
-    return socket;
+    const { devices, ...restConfig } = config ?? {} as SocketLegacyBasicConfig;
+    return GatewayConnectorVersionMappingUtil.cleanUpConfigBaseInfo(restConfig as SocketLegacyBasicConfig) as SocketConfig;
   }
 
   static mapSocketToDowngradedVersion(config: SocketBasicConfig_v3_6): SocketLegacyBasicConfig {

--- a/src/app/gateway/states/gateway-service-rpc/components/gateway-service-rpc-connector/gateway-service-rpc-connector.component.ts
+++ b/src/app/gateway/states/gateway-service-rpc/components/gateway-service-rpc-connector/gateway-service-rpc-connector.component.ts
@@ -32,7 +32,6 @@ import {
   BLEMethods,
   BLEMethodsTranslates,
   CANByteOrders,
-  HTTPMethods,
   RPCCommand,
   RPCTemplateConfig,
   SNMPMethods,
@@ -42,7 +41,8 @@ import {
   ConnectorType,
   GatewayConnectorDefaultTypesTranslatesMap,
   noLeadTrailSpacesRegex,
-  jsonRequired
+  jsonRequired,
+  HTTPMethods,
 } from '../../../../shared/public-api';
 import { MatDialog } from '@angular/material/dialog';
 import {

--- a/src/app/gateway/states/gateway-service-rpc/models/rpc.models.ts
+++ b/src/app/gateway/states/gateway-service-rpc/models/rpc.models.ts
@@ -100,19 +100,6 @@ export const SNMPMethodsTranslations = new Map<SNMPMethods, string>([
   [SNMPMethods.WALKS, 'gateway.rpc.walk']
 ]);
 
-export enum HTTPMethods {
-  CONNECT = 'CONNECT',
-  DELETE = 'DELETE',
-  GET = 'GET',
-  HEAD = 'HEAD',
-  OPTIONS = 'OPTIONS',
-  PATCH = 'PATCH',
-  POST = 'POST',
-  PUT = 'PUT',
-  TRACE = 'TRACE'
-
-}
-
 export enum SocketEncodings {
   UTF_8 = 'utf-8'
 }

--- a/src/app/scss/style.scss
+++ b/src/app/scss/style.scss
@@ -13,8 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-.tb-gateway {
+.gw-delete-icon-button {
+  color: rgba(0, 0, 0, 0.54);
+}
 
+.gw-connector-table {
+  .mat-mdc-table {
+    table-layout: fixed;
+  }
+}
+
+.gw-chip-list {
+  .mdc-evolution-chip-set__chips {
+    justify-content: flex-end;
+    align-items: center;
+  }
+}
+
+.gw-table-toolbar.mat-mdc-table-toolbar.mat-mdc-table-toolbar  {
+  padding: 0 8px;
 }
 
 /***************


### PR DESCRIPTION
Aligned master with 4.0 changes and fixes

Key changes: 
- some translations refinement
- added tb-error-icon and implemented implemented it in OPC/MQTT
- added mode for security component
- removed unnecessary styles for show help buttons
- removed unnecessary @ts-ignore
- removed unnecessary connector types for withReportStrategy pipe in connectors component
- ConvertorType interface changes
- fixed socket bug, socket had unnecessary connector configs on upgrade
- added global styles
