### PR TITLE
POC of json validation basic implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "npm": "Please use yarn instead of NPM to install dependencies"
   },
   "dependencies": {
-    "echarts": "https://github.com/thingsboard/echarts/archive/5.5.0-TB.tar.gz"
+    "echarts": "https://github.com/thingsboard/echarts/archive/5.5.0-TB.tar.gz",
+    "json-source-map": "^0.6.1",
+    "jsonschema": "^1.5.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "18.2.7",
@@ -59,8 +61,8 @@
     "eslint-plugin-import": "latest",
     "eslint-plugin-jsdoc": "latest",
     "eslint-plugin-prefer-arrow": "latest",
-    "license-check-and-add": "^4.0.5",
     "eslint-plugin-tailwindcss": "^3.17.5",
+    "license-check-and-add": "^4.0.5",
     "ng-packagr": "18.2.1",
     "ngrx-store-freeze": "^0.2.4",
     "patch-package": "^8.0.0",

--- a/src/app/gateway/shared/abstract/control-value-accessor-base.abstract.ts
+++ b/src/app/gateway/shared/abstract/control-value-accessor-base.abstract.ts
@@ -16,56 +16,56 @@
 
 import { DestroyRef, Directive, inject } from '@angular/core';
 import {
+  AbstractControl,
   ControlValueAccessor,
   FormBuilder,
-  FormGroup,
   ValidationErrors,
   Validator
 } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Directive()
-export abstract class ControlValueAccessorBaseAbstract<FormValueType> implements ControlValueAccessor, Validator {
+export abstract class ControlValueAccessorBaseAbstract<InputFormValueType, OutputFormValueType = InputFormValueType> implements ControlValueAccessor, Validator {
 
-  formGroup: FormGroup;
+  form: AbstractControl;
 
-  protected onChange!: (value: FormValueType) => void;
+  protected onChange!: (value: OutputFormValueType) => void;
   protected fb = inject(FormBuilder);
   protected destroyRef = inject(DestroyRef);
 
   constructor() {
-    this.formGroup = this.initFormGroup();
+    this.form = this.initFormGroup();
 
     this.observeValueChanges();
   }
 
-  registerOnChange(fn: (value: FormValueType) => void): void {
+  registerOnChange(fn: (value: OutputFormValueType) => void): void {
     this.onChange = fn;
   }
 
   registerOnTouched(_: () => void): void {}
 
   validate(): ValidationErrors | null {
-    return this.formGroup.valid ? null : {
-      formGroup: { valid: false }
+    return this.form.valid ? null : {
+      form: { valid: false }
     };
   }
 
-  writeValue(value: FormValueType): void {
+  writeValue(value: OutputFormValueType): void {
     this.onWriteValue(value);
   }
 
-  protected onWriteValue(value: FormValueType): void {
-    this.formGroup.patchValue(value, { emitEvent: false });
+  protected onWriteValue(value: OutputFormValueType): void {
+    this.form.patchValue(value, { emitEvent: false });
   }
 
-  protected mapOnChangeValue(value: unknown): FormValueType {
-    return value as FormValueType;
+  protected mapOnChangeValue(value: unknown): OutputFormValueType {
+    return value as OutputFormValueType;
   }
 
   protected observeValueChanges(): void {
-    this.formGroup.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.onChange(this.mapOnChangeValue(value)));
+    this.form.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.onChange(this.mapOnChangeValue(value)));
   }
 
-  protected abstract initFormGroup(): FormGroup;
+  protected abstract initFormGroup(): AbstractControl;
 }

--- a/src/app/gateway/states/gateway-connectors/abstract/connector-config-validation.abstract.ts
+++ b/src/app/gateway/states/gateway-connectors/abstract/connector-config-validation.abstract.ts
@@ -1,0 +1,85 @@
+///
+/// Copyright © 2016-2025 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import {
+  GatewayConnectorVersionMappingUtil
+} from '../utils/public-api';
+import { GatewayVersion } from '../../../shared/models/gateway.models';
+import { ValidatorResult } from 'jsonschema';
+import { parse } from 'json-source-map';
+
+export abstract class ConnectorConfigValidationAbstract {
+  gatewayVersion: number;
+  configVersion: number;
+
+  protected constructor(protected gatewayVersionIn: string | number, protected configurationJson: any) {
+    this.gatewayVersion = GatewayConnectorVersionMappingUtil.parseVersion(this.gatewayVersionIn);
+    this.configVersion = GatewayConnectorVersionMappingUtil.parseVersion(this.configurationJson?.configVersion ?? GatewayVersion.Legacy);
+  }
+
+  protected jsonPathToPointer(pathArray: (string | number)[]): string {
+    if (!pathArray || pathArray.length === 0) return '';
+    return (
+      '/' +
+      pathArray
+        .map(segment =>
+          typeof segment === 'number'
+            ? segment
+            : segment.replace(/~/g, '~0').replace(/\//g, '~1')
+        )
+        .join('/')
+    );
+  }
+
+  protected mapValidatorErrorsToAceAnnotations(
+    rawJson: string,
+    validationResult: ValidatorResult
+  ) {
+    const annotations = [];
+
+    const { pointers } = parse(rawJson);
+
+    for (const error of validationResult.errors) {
+      const pointerPath = this.jsonPathToPointer(error.path);
+      const pointerInfo = pointers[pointerPath];
+
+      if (pointerInfo?.key) {
+        annotations.push({
+          row: pointerInfo.key.line,
+          column: pointerInfo.key.column,
+          text: error.stack,
+          type: 'error'
+        });
+      } else if (pointerInfo?.value) {
+        annotations.push({
+          row: pointerInfo.value.line,
+          column: pointerInfo.value.column,
+          text: error.stack,
+          type: 'error'
+        });
+      } else {
+        annotations.push({
+          row: 0,
+          column: 0,
+          text: error.stack,
+          type: 'error'
+        });
+      }
+    }
+
+    return annotations;
+  }
+}

--- a/src/app/gateway/states/gateway-connectors/abstract/gateway-connector-basic-config.abstract.ts
+++ b/src/app/gateway/states/gateway-connectors/abstract/gateway-connector-basic-config.abstract.ts
@@ -29,7 +29,7 @@ import { ControlValueAccessorBaseAbstract } from '../../../shared/abstract/publi
 
 @Directive()
 export abstract class GatewayConnectorBasicConfigDirective<InputBasicConfig, OutputBasicConfig>
-  extends ControlValueAccessorBaseAbstract<OutputBasicConfig>
+  extends ControlValueAccessorBaseAbstract<InputBasicConfig, OutputBasicConfig>
   implements AfterViewInit {
 
   @Input() generalTabContent: TemplateRef<any>;
@@ -43,7 +43,7 @@ export abstract class GatewayConnectorBasicConfigDirective<InputBasicConfig, Out
   protected onChange!: (value: OutputBasicConfig) => void;
 
   get basicFormGroup(): FormGroup {
-    return this.formGroup;
+    return this.form as FormGroup;
   }
 
   ngAfterViewInit(): void {
@@ -51,7 +51,7 @@ export abstract class GatewayConnectorBasicConfigDirective<InputBasicConfig, Out
   }
 
   protected override onWriteValue(config: OutputBasicConfig): void {
-    this.formGroup.setValue(this.mapConfigToFormValue(config), { emitEvent: false });
+    this.form.setValue(this.mapConfigToFormValue(config), { emitEvent: false });
   }
 
   protected override mapOnChangeValue(config: InputBasicConfig): OutputBasicConfig {

--- a/src/app/gateway/states/gateway-connectors/abstract/public-api.ts
+++ b/src/app/gateway/states/gateway-connectors/abstract/public-api.ts
@@ -23,3 +23,4 @@ export * from './socket-version-processor.abstract';
 export * from './bacnet-version-processor.abstract';
 export * from './basic-config-entity-table.abstract';
 export * from './rest-version-processor.abstract';
+export * from './connector-config-validation.abstract';

--- a/src/app/gateway/states/gateway-connectors/components/advanced/connector-advanced-config.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/advanced/connector-advanced-config.component.html
@@ -1,0 +1,29 @@
+<!--
+  Copyright © 2016-2025 The Thingsboard Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<mat-tab-group>
+  <mat-tab label="{{ 'gateway.general' | translate }}">
+    <ng-container [ngTemplateOutlet]="generalTabContent"></ng-container>
+  </mat-tab>
+  <mat-tab label="{{ 'gateway.configuration' | translate }}*">
+    <tb-json-object-edit
+      class="configuration-json"
+      [fillHeight]="true"
+      jsonRequired
+      label="{{ 'gateway.configuration' | translate }}"
+      [formControl]="jsonConfigFormControl">
+    </tb-json-object-edit>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/gateway/states/gateway-connectors/components/advanced/connector-advanced-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/advanced/connector-advanced-config.component.ts
@@ -1,0 +1,107 @@
+///
+/// Copyright © 2016-2025 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  Input,
+  TemplateRef,
+  ViewChild
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  AbstractControl,
+  FormControl,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ValidationErrors,
+  ValidatorFn,
+} from '@angular/forms';
+import { SharedModule } from '@shared/public-api';
+import { ControlValueAccessorBaseAbstract } from '../../../../shared/abstract/control-value-accessor-base.abstract';
+import { ConnectorConfigValidationUtil } from '../../utils/connector-config-validation.util';
+import { ConnectorType, GatewayVersion } from '../../../../shared/models/gateway.models';
+import { JsonObjectEditComponent } from '@shared/components/json-object-edit.component';
+
+@Component({
+  selector: 'tb-connector-advanced-config',
+  templateUrl: './connector-advanced-config.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ConnectorAdvancedConfigComponent),
+      multi: true
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => ConnectorAdvancedConfigComponent),
+      multi: true
+    }
+  ],
+  standalone: true,
+  imports: [
+    CommonModule,
+    SharedModule,
+  ],
+})
+export class ConnectorAdvancedConfigComponent extends ControlValueAccessorBaseAbstract<any> implements AfterViewInit {
+
+  @Input() generalTabContent: TemplateRef<any>;
+  @Input() gatewayVersion: GatewayVersion = GatewayVersion.Legacy;
+  @Input() type: ConnectorType;
+  @ViewChild(JsonObjectEditComponent, {static: true}) jsonObjectEdit: JsonObjectEditComponent;
+
+  private annotations = [];
+  private annotationChanged = false;
+
+  get jsonConfigFormControl(): FormControl {
+    return this.form as FormControl;
+  }
+
+  protected initFormGroup(): FormControl {
+    return this.fb.control({ value: {} }, [this.jsonConfigValidator()]);
+  }
+
+  ngAfterViewInit(): void {
+    const editor = this.jsonObjectEdit?.['jsonEditor'];
+    editor?.renderer.on('afterRender', () => {
+      const currentAnnotations = editor.session.getAnnotations();
+      if (!currentAnnotations.length && this.annotations.length) {
+        this.annotationChanged = true;
+      }
+      if (this.annotationChanged) {
+        const syntaxAnnotation = currentAnnotations.find(annotation => !annotation?.custom);
+        this.annotationChanged = false;
+        editor.session.setAnnotations(syntaxAnnotation ? [syntaxAnnotation, ...this.annotations] : this.annotations);
+      }
+    });
+  }
+
+  jsonConfigValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const editor = this.jsonObjectEdit?.['jsonEditor'];
+      if (!editor || !control.valid) {
+        return null;
+      }
+      const schemaErrors = ConnectorConfigValidationUtil.getSchemaErrors(editor.getValue(), this.type, this.gatewayVersion);
+      this.annotations = schemaErrors.map(item => ({ ...item, custom: true }));
+      this.annotationChanged = true;
+      return !schemaErrors.length ? null : { invalidConfig: { valid: false } };
+    };
+  }
+}

--- a/src/app/gateway/states/gateway-connectors/components/bacnet/application-config/bacnet-application-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/bacnet/application-config/bacnet-application-config.component.ts
@@ -16,9 +16,9 @@
 import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
+  FormGroup,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
-  UntypedFormGroup,
   Validators
 } from '@angular/forms';
 import { SharedModule } from '@shared/public-api';
@@ -60,11 +60,11 @@ export class BacnetApplicationConfigComponent extends ControlValueAccessorBaseAb
   readonly SegmentationTypeTranslationsMap = SegmentationTypeTranslationsMap;
   readonly portLimits = PortLimits;
 
-  get applicationConfigFormGroup(): UntypedFormGroup {
-    return this.formGroup;
+  get applicationConfigFormGroup(): FormGroup {
+    return this.form as FormGroup;
   }
 
-  protected override initFormGroup(): UntypedFormGroup {
+  protected override initFormGroup(): FormGroup {
     return this.fb.group({
       objectName: ['', [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]],
       host: ['', [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]],
@@ -92,6 +92,6 @@ export class BacnetApplicationConfigComponent extends ControlValueAccessorBaseAb
       deviceDiscoveryTimeoutInSec = 5,
       ...restConfig
     } = applicationConfig;
-    this.formGroup.reset({ ...restConfig, maxApduLengthAccepted, segmentationSupported, networkNumber, deviceDiscoveryTimeoutInSec }, { emitEvent: false });
+    this.applicationConfigFormGroup.reset({ ...restConfig, maxApduLengthAccepted, segmentationSupported, networkNumber, deviceDiscoveryTimeoutInSec }, { emitEvent: false });
   }
 }

--- a/src/app/gateway/states/gateway-connectors/components/bacnet/device-data-key/bacnet-device-data-key.component.html
+++ b/src/app/gateway/states/gateway-connectors/components/bacnet/device-data-key/bacnet-device-data-key.component.html
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<div class="tb-form-panel no-border no-padding" [formGroup]="formGroup">
+<div class="tb-form-panel no-border no-padding" [formGroup]="bacnetDeviceKeyFormGroup">
   <div class="tb-form-panel stroked">
     <div class="tb-form-panel-title" translate>gateway.platform-side</div>
     <div class="tb-form-row column-xs">
@@ -28,7 +28,7 @@
         <mat-form-field class="tb-flex no-gap" appearance="outline" subscriptSizing="dynamic">
           <input matInput name="value" formControlName="key"
                  placeholder="{{ 'gateway.set' | translate }}"/>
-          @if (formGroup.get('key').hasError('required') && formGroup.get('key').touched) {
+          @if (form.get('key').hasError('required') && form.get('key').touched) {
             <mat-icon matSuffix
                       matTooltipPosition="above"
                       matTooltipClass="tb-error-tooltip"
@@ -48,7 +48,7 @@
         <mat-form-field class="tb-flex no-gap" appearance="outline" subscriptSizing="dynamic">
           <input matInput name="value" formControlName="method"
                  placeholder="{{ 'gateway.set' | translate }}"/>
-          @if (formGroup.get('method').hasError('required') && formGroup.get('method').touched) {
+          @if (form.get('method').hasError('required') && form.get('method').touched) {
             <mat-icon matSuffix
                       matTooltipPosition="above"
                       matTooltipClass="tb-error-tooltip"
@@ -102,7 +102,7 @@
       <div class="tb-form-table-row-cell tb-flex no-gap">
         <mat-form-field class="tb-flex no-gap" appearance="outline" subscriptSizing="dynamic">
           <input matInput type="number" min="0" name="value" formControlName="objectId" placeholder="{{ 'gateway.set' | translate }}"/>
-          @if (formGroup.get('objectId').hasError('required') && formGroup.get('objectId').touched) {
+          @if (form.get('objectId').hasError('required') && form.get('objectId').touched) {
             <mat-icon matSuffix
                       matTooltipPosition="above"
                       matTooltipClass="tb-error-tooltip"

--- a/src/app/gateway/states/gateway-connectors/components/bacnet/device-data-key/bacnet-device-data-key.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/bacnet/device-data-key/bacnet-device-data-key.component.ts
@@ -14,7 +14,7 @@
 /// limitations under the License.
 ///
 import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, Input, OnInit } from '@angular/core';
-import { NG_VALIDATORS, NG_VALUE_ACCESSOR, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormGroup, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 
@@ -72,8 +72,12 @@ export class BacnetDeviceDataKeyComponent extends ControlValueAccessorBaseAbstra
   readonly BacnetPropertyIdTranslationsMap = BacnetPropertyIdTranslationsMap;
   readonly BacnetRequestTypeTranslationsMap = BacnetRequestTypeTranslationsMap;
 
+  get bacnetDeviceKeyFormGroup(): FormGroup {
+    return this.form as FormGroup;
+  }
+
   ngOnInit(): void {
-    this.formGroup = this.initKeyFormGroup();
+    this.form = this.initKeyFormGroup();
     this.observeValueChanges();
     this.observeObjectType();
   }
@@ -82,7 +86,7 @@ export class BacnetDeviceDataKeyComponent extends ControlValueAccessorBaseAbstra
     return !(this.withReportStrategy && (this.keyType === BacnetDeviceKeysType.ATTRIBUTES || this.keyType === BacnetDeviceKeysType.TIMESERIES));
   }
 
-  private initKeyFormGroup(): UntypedFormGroup {
+  private initKeyFormGroup(): FormGroup {
     return this.fb.group({
       key: [{ value: '', disabled: this.keyType === BacnetDeviceKeysType.RPC_METHODS }, [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]],
       method: [{ value: '', disabled: this.keyType !== BacnetDeviceKeysType.RPC_METHODS }, [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]],
@@ -96,17 +100,17 @@ export class BacnetDeviceDataKeyComponent extends ControlValueAccessorBaseAbstra
   }
 
   private observeObjectType(): void {
-    this.formGroup.get('objectType').valueChanges
+    this.bacnetDeviceKeyFormGroup.get('objectType').valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(type => {
         this.propertyIds = BacnetPropertyIdByObjectType.get(type);
-        if (!this.propertyIds.includes(this.formGroup.get('propertyId').value)) {
-          this.formGroup.get('propertyId').patchValue(this.propertyIds[0], {emitEvent: false});
+        if (!this.propertyIds.includes(this.bacnetDeviceKeyFormGroup.get('propertyId').value)) {
+          this.bacnetDeviceKeyFormGroup.get('propertyId').patchValue(this.propertyIds[0], {emitEvent: false});
         }
       });
   }
 
-  protected initFormGroup(): UntypedFormGroup {
+  protected initFormGroup(): FormGroup {
     return this.fb.group({});
   }
 

--- a/src/app/gateway/states/gateway-connectors/components/public-api.ts
+++ b/src/app/gateway/states/gateway-connectors/components/public-api.ts
@@ -16,12 +16,9 @@
 
 export * from './add-connector-dialog/add-connector-dialog.component';
 export * from './mapping-dialog/mapping-dialog.component';
-// export * from './mapping-data-keys-panel/mapping-data-keys-panel.component';
-// export * from './device-info-table/device-info-table.component';
-// export * from './type-value-panel/type-value-panel.component';
 export * from './mapping-table/mapping-table.component';
 export * from './security-config/security-config.component';
-// export * from './type-value-field/type-value-field.component';
+export * from './advanced/connector-advanced-config.component';
 
 export * from './opc/public-api';
 export * from './mqtt/public-api';

--- a/src/app/gateway/states/gateway-connectors/components/rest/response-config/rest-response-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/rest/response-config/rest-response-config.component.ts
@@ -23,7 +23,6 @@ import {
   FormGroup,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
-  UntypedFormGroup,
   Validators,
 } from '@angular/forms';
 import { SharedModule } from '@shared/public-api';
@@ -65,8 +64,8 @@ export class RestResponseConfigComponent extends ControlValueAccessorBaseAbstrac
   readonly responseTypes = Object.values(ResponseType) as ResponseType[];
   readonly responseStatuses = Object.values(ResponseStatus) as ResponseStatus[];
 
-  get responseConfigFormGroup(): UntypedFormGroup {
-    return this.formGroup;
+  get responseConfigFormGroup(): FormGroup {
+    return this.form as FormGroup;
   }
 
   constructor() {

--- a/src/app/gateway/states/gateway-connectors/components/rest/server-config/rest-server-config.component.ts
+++ b/src/app/gateway/states/gateway-connectors/components/rest/server-config/rest-server-config.component.ts
@@ -16,9 +16,9 @@
 import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
+  FormGroup,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
-  UntypedFormGroup,
   Validators
 } from '@angular/forms';
 import { SharedModule } from '@shared/public-api';
@@ -61,11 +61,11 @@ export class RestServerConfigComponent extends ControlValueAccessorBaseAbstract<
 
   readonly portLimits = PortLimits;
 
-  get serverConfigFormGroup(): UntypedFormGroup {
-    return this.formGroup;
+  get serverConfigFormGroup(): FormGroup {
+    return this.form as FormGroup;
   }
 
-  protected override initFormGroup(): UntypedFormGroup {
+  protected override initFormGroup(): FormGroup {
     return this.fb.group({
       host: ['', [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]],
       port: [null, [Validators.required, Validators.min(PortLimits.MIN), Validators.max(PortLimits.MAX)]],
@@ -83,6 +83,6 @@ export class RestServerConfigComponent extends ControlValueAccessorBaseAbstract<
   }
 
   protected override onWriteValue(serverConfig: RestServerConfig): void {
-    this.formGroup.reset(serverConfig, { emitEvent: false });
+    this.form.reset(serverConfig, { emitEvent: false });
   }
 }

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.html
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.html
@@ -276,20 +276,13 @@
         </ng-container>
       </ng-container>
       <ng-template #defaultConfig>
-        <mat-tab-group>
-          <mat-tab label="{{ 'gateway.general' | translate }}">
-            <ng-container [ngTemplateOutlet]="generalTabContent"></ng-container>
-          </mat-tab>
-          <mat-tab label="{{ 'gateway.configuration' | translate }}*">
-            <tb-json-object-edit
-              class="configuration-json"
-              [fillHeight]="true"
-              jsonRequired
-              label="{{ 'gateway.configuration' | translate }}"
-              formControlName="configurationJson">
-            </tb-json-object-edit>
-          </mat-tab>
-        </mat-tab-group>
+        <tb-connector-advanced-config
+          class="h-full"
+          [generalTabContent]="generalTabContent"
+          [gatewayVersion]="gatewayVersion"
+          [type]="connectorForm.get('type').value"
+          formControlName="configurationJson"
+        />
       </ng-template>
       <div class="flex justify-end">
         <button mat-raised-button color="primary"

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.scss
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.scss
@@ -153,13 +153,5 @@
       }
     }
   }
-
-  .configuration-json {
-    .ace_tooltip {
-      @media #{constants.$mat-gt-sm} {
-        transform: translate(-250px, -120px);
-      }
-    }
-  }
 }
 

--- a/src/app/gateway/states/gateway-connectors/gateway-connectors.component.ts
+++ b/src/app/gateway/states/gateway-connectors/gateway-connectors.component.ts
@@ -43,12 +43,14 @@ import {
   GatewayConnector,
   GatewayConnectorDefaultTypesTranslatesMap,
   GatewayLogLevel,
+  GatewayVersion,
   noLeadTrailSpacesRegex,
   ReportStrategyDefaultValue,
 } from '../../shared/models/public-api';
 import { MatDialog } from '@angular/material/dialog';
 import {
   AddConnectorDialogComponent,
+  ConnectorAdvancedConfigComponent,
   ModbusBasicConfigComponent,
   ModbusLegacyBasicConfigComponent,
   MqttBasicConfigComponent,
@@ -115,6 +117,7 @@ export class ForceErrorStateMatcher implements ErrorStateMatcher {
     BacnetLegacyBasicConfigComponent,
     RestLegacyBasicConfigComponent,
     RestBasicConfigComponent,
+    ConnectorAdvancedConfigComponent,
   ],
 })
 export class GatewayConnectorComponent extends PageComponent implements AfterViewInit, OnDestroy {
@@ -145,8 +148,8 @@ export class GatewayConnectorComponent extends PageComponent implements AfterVie
   activeConnectors: Array<string>;
   initialConnector: GatewayConnector;
   basicConfigInitSubject = new Subject<void>();
+  gatewayVersion: GatewayVersion;
 
-  private gatewayVersion: string;
   private isGatewayActive: boolean;
   private inactiveConnectors: Array<string>;
   private attributeDataSource: AttributeDatasource;

--- a/src/app/gateway/states/gateway-connectors/models/connectors.schema.ts
+++ b/src/app/gateway/states/gateway-connectors/models/connectors.schema.ts
@@ -1,0 +1,92 @@
+///
+/// Copyright © 2016-2025 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+import { SourceType } from './connectors.model';
+
+export const ValueTypeSchema = {
+  type: 'object',
+  required: ['type', 'value'],
+  properties: {
+    type: {
+      type: 'string',
+      enum: ['string', 'integer', 'double', 'boolean']
+    },
+    value: {
+      oneOf: [
+        { type: 'string' },
+        { type: 'number' },
+        { type: 'boolean' }
+      ]
+    }
+  }
+};
+
+export const RpcMethodSchema = {
+  type: 'object',
+  required: ['method', 'arguments'],
+  properties: {
+    method: { type: 'string' },
+    arguments: {
+      type: 'array',
+      items: ValueTypeSchema
+    }
+  }
+};
+
+export const DataKeySchema = {
+  type: 'object',
+  required: ['key', 'type', 'value'],
+  properties: {
+    key: { type: 'string' },
+    type: { type: 'string' },
+    value: { type: 'string' }
+  }
+};
+
+export const ConnectorSecuritySchema = {
+  type: 'object',
+  required: ['type'],
+  properties: {
+    type: { type: 'string' },
+    username: { type: 'string' },
+    password: { type: 'string' },
+    pathToCACert: { type: 'string' },
+    pathToPrivateKey: { type: 'string' },
+    pathToClientCert: { type: 'string' },
+    mode: { type: 'string' }
+  }
+};
+
+export const getConnectorDeviceInfoSchema = (sourceTypes: SourceType[])=> ({
+  type: 'object',
+  required: [
+    'deviceNameExpression',
+    'deviceNameExpressionSource',
+    'deviceProfileExpression',
+    'deviceProfileExpressionSource'
+  ],
+  properties: {
+    deviceNameExpression: { type: 'string' },
+    deviceNameExpressionSource: {
+      type: 'string',
+      enum: sourceTypes
+    },
+    deviceProfileExpression: { type: 'string' },
+    deviceProfileExpressionSource: {
+      type: 'string',
+      enum: sourceTypes
+    }
+  }
+});

--- a/src/app/gateway/states/gateway-connectors/models/opc.models.ts
+++ b/src/app/gateway/states/gateway-connectors/models/opc.models.ts
@@ -17,12 +17,12 @@ import {
   AttributesUpdate,
   ConnectorDeviceInfo,
   ConnectorSecurity,
-  DevicesConfigMapping,
   LegacyAttribute,
   LegacyRpcMethod,
   LegacyTimeseries,
   OPCUaSourceType,
-  RpcMethod
+  RpcMethod,
+  SecurityPolicy
 } from './connectors.model';
 import { Attribute, Timeseries } from '../../../shared/models/gateway.models';
 
@@ -35,7 +35,7 @@ export interface ServerConfig {
   enableSubscriptions: boolean;
   subCheckPeriodInMillis: number;
   showMap: boolean;
-  security: string;
+  security: SecurityPolicy;
   identity: ConnectorSecurity;
 }
 

--- a/src/app/gateway/states/gateway-connectors/models/opc.schema.ts
+++ b/src/app/gateway/states/gateway-connectors/models/opc.schema.ts
@@ -1,0 +1,89 @@
+///
+/// Copyright © 2016-2025 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+import {
+  ConnectorSecuritySchema,
+  RpcMethodSchema,
+  getConnectorDeviceInfoSchema,
+  DataKeySchema,
+} from './connectors.schema';
+import { OPCUaSourceType, SecurityPolicy } from './connectors.model';
+
+export const OPCBasicConfigSchema = {
+  title: 'OPCBasicConfig_v3_5_2',
+  type: 'object',
+  properties: {
+    mapping: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['deviceNodePattern', 'deviceNodeSource', 'deviceInfo'],
+        properties: {
+          deviceNodePattern: { type: 'string' },
+          deviceNodeSource: {
+            type: 'string',
+            enum: Object.values(OPCUaSourceType)
+          },
+          deviceInfo: getConnectorDeviceInfoSchema(Object.values(OPCUaSourceType)),
+          attributes: {
+            type: 'array',
+            items: DataKeySchema
+          },
+          timeseries: {
+            type: 'array',
+            items: DataKeySchema
+          },
+          rpc_methods: {
+            type: 'array',
+            items: RpcMethodSchema
+          },
+          attributes_updates: {
+            type: 'array',
+            items: DataKeySchema
+          }
+        }
+      }
+    },
+    server: {
+      type: 'object',
+      required: [
+        'url',
+        'timeoutInMillis',
+        'scanPeriodInMillis',
+        'pollPeriodInMillis',
+        'enableSubscriptions',
+        'subCheckPeriodInMillis',
+        'showMap',
+        'security',
+        'identity'
+      ],
+      properties: {
+        url: { type: 'string' },
+        timeoutInMillis: { type: 'integer' },
+        scanPeriodInMillis: { type: 'integer' },
+        pollPeriodInMillis: { type: 'integer' },
+        enableSubscriptions: { type: 'boolean' },
+        subCheckPeriodInMillis: { type: 'integer' },
+        showMap: { type: 'boolean' },
+        security: {
+          type: 'string',
+          enum: Object.values(SecurityPolicy)
+        },
+        identity: ConnectorSecuritySchema
+      }
+    }
+  },
+  required: ['server', 'mapping']
+};

--- a/src/app/gateway/states/gateway-connectors/models/public-api.ts
+++ b/src/app/gateway/states/gateway-connectors/models/public-api.ts
@@ -20,3 +20,5 @@ export * from './opc.models';
 export * from './socket.models';
 export * from './bacnet.models';
 export * from './rest.models';
+export * from './opc.schema';
+export * from './connectors.schema';

--- a/src/app/gateway/states/gateway-connectors/utils/connector-config-validation.util.ts
+++ b/src/app/gateway/states/gateway-connectors/utils/connector-config-validation.util.ts
@@ -1,0 +1,32 @@
+///
+/// Copyright © 2016-2025 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import { ConnectorType } from '../../../shared/models/public-api';
+import { OpcConfigValidationUtil } from './opc-config-validation.util';
+import { OPCBasicConfigSchema } from '../models/opc.schema';
+import { ValidatorResult } from 'jsonschema';
+
+export abstract class ConnectorConfigValidationUtil {
+
+  static getSchemaErrors(configurationJson = {}, type: ConnectorType, gatewayVersion: string): any {
+    switch(type) {
+      case ConnectorType.OPCUA:
+        return new OpcConfigValidationUtil(gatewayVersion, configurationJson, OPCBasicConfigSchema).getSchemaErrors();
+      default:
+        return { valid: true } as ValidatorResult;
+    }
+  }
+}

--- a/src/app/gateway/states/gateway-connectors/utils/opc-config-validation.util.ts
+++ b/src/app/gateway/states/gateway-connectors/utils/opc-config-validation.util.ts
@@ -1,0 +1,46 @@
+///
+/// Copyright © 2016-2025 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import { ConnectorConfigValidationAbstract } from '../abstract/connector-config-validation.abstract';
+import { Validator, ValidatorResult } from 'jsonschema';
+
+export class OpcConfigValidationUtil extends ConnectorConfigValidationAbstract {
+  gatewayVersion: number;
+  configVersion: number;
+
+  constructor(protected gatewayVersionIn: string | number, protected configurationJson: any, protected configSchema: any) {
+    super(gatewayVersionIn, configurationJson);
+  }
+
+  private getValidatorResult(): ValidatorResult {
+    let parsedJson;
+    try {
+      parsedJson = JSON.parse(this.configurationJson);
+    } catch (_) {
+      return { valid: true } as ValidatorResult;
+    }
+    if (!this.configurationJson) return { valid: false } as ValidatorResult;
+    return new Validator().validate(parsedJson, this.configSchema);
+  }
+
+  getSchemaErrors(): any[] {
+    const validatorResult = this.getValidatorResult();
+    if (validatorResult.valid || !this.configurationJson) {
+      return [];
+    }
+    return this.mapValidatorErrorsToAceAnnotations(this.configurationJson, validatorResult);
+  }
+}

--- a/src/app/gateway/states/gateway-service-rpc/components/socket-rpc-parameters/socket-rpc-parameters.component.html
+++ b/src/app/gateway/states/gateway-service-rpc/components/socket-rpc-parameters/socket-rpc-parameters.component.html
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<ng-container [formGroup]="formGroup">
+<ng-container [formGroup]="socketRpcParametersFormGroup">
   <mat-form-field class="w-full">
     <mat-label>{{ 'gateway.rpc.methodRPC' | translate }}</mat-label>
     <input matInput formControlName="methodRPC" placeholder="rpcMethod1"/>

--- a/src/app/gateway/states/gateway-service-rpc/components/socket-rpc-parameters/socket-rpc-parameters.component.ts
+++ b/src/app/gateway/states/gateway-service-rpc/components/socket-rpc-parameters/socket-rpc-parameters.component.ts
@@ -64,6 +64,10 @@ export class SocketRpcParametersComponent extends ControlValueAccessorBaseAbstra
   readonly socketMethodProcessings = Object.values(SocketMethodProcessings) as SocketMethodProcessings[];
   readonly socketEncoding = Object.values(SocketEncoding) as SocketEncoding[];
 
+  get socketRpcParametersFormGroup(): FormGroup {
+    return this.form as FormGroup;
+  }
+
   protected initFormGroup(): FormGroup {
     return this.fb.group({
       methodRPC: [null, [Validators.required, Validators.pattern(noLeadTrailSpacesRegex)]],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6919,6 +6919,11 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+json-source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/json-source-map/-/json-source-map-0.6.1.tgz#e0b1f6f4ce13a9ad57e2ae165a24d06e62c79a0f"
+  integrity sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -6977,6 +6982,11 @@ jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
+
+jsonschema@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.5.0.tgz#f6aceb1ab9123563dd901d05f81f9d4883d3b7d8"
+  integrity sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==
 
 karma-source-map-support@1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## ✨ JSON Schema Validation in Ace Editor for OPC Connector (POC)
![Screenshot from 2025-04-18 16-33-34](https://github.com/user-attachments/assets/0971d24e-b47f-4484-ad26-0108b547428f)

### Overview

This PR introduces a **proof-of-concept implementation** of real-time JSON Schema validation integrated with **Ace Editor annotations** for the **OPC connector** configuration.

It highlights schema validation errors *directly in the editor* using `jsonschema` and `json-source-map`, mapping errors to their precise locations in the JSON source.

---

### ✅ Implemented Functionality

- **Schema validation**:
  - Uses [`jsonschema`](https://github.com/tdegrunt/jsonschema) to validate OPC connector configuration
  - Validation errors are derived from the parsed config and mapped to pointer paths using `json-source-map`

- **Editor annotations**:
  - Ace Editor annotations show up on each content change
  - Errors are mapped to accurate `row` and `column` using the original JSON string (with preserved formatting)
  - Invalid JSON shows a single annotation at the start — this is **intended behavior**

- **Annotation mapper**:
  - Converts `ValidatorResult.errors` into Ace Editor annotations
  - Safely handles missing or unresolved pointer paths
  - Built to work with `json-source-map` pointers output and Ace-compatible notation

---

### 🔧 Scope

This is implemented **only for the OPC connector**.  
Other connectors (e.g. MQTT, Modbus, etc.) are **not yet supported** and will require:
- A schema definition
- A dedicated validation processor implementation

---

### 📌 Known Gaps / To-Dos

- ❗ `ConnectorAdvancedConfigComponent` needs **performance optimization**
  - Currently, validation runs on every keystroke without throttling
  - Potential delay on large JSON inputs

- ❗ **Connector extension required**
  - Validation logic and schema support for non-OPC connectors must be added
  - Processor pattern can be reused from OPC

- ✅ Range-based highlighting is **not required** and intentionally not implemented

---

### 🔍 Entry Points

- `ConnectorAdvancedConfigComponent`
  - Contains validation trigger + Ace editor integration
- `mapValidatorErrorsToAceAnnotations()`
  - Core logic that maps validation errors to Ace annotation format
- `ConnectorConfigValidationUtil`
  - OPC-specific schema error retrieval

---

### 🧭 Next Developer Handoff Notes

- Use `editor.getValue()` to feed raw JSON into `json-source-map`
- Use `parse(rawString)` (not `stringify(obj)`) to ensure line/column mapping is accurate
- Stick with Ace-style annotations: `{ row, column, text, type }`
- Reuse the pattern when extending to other connectors (schema + processor)

---

### 🧪 Sample Error Output

```json
[
  {
    "row": 12,
    "column": 15,
    "text": "Invalid type: expected integer",
    "type": "error"
  }
]
