### PR TITLE
Fixed error overlap on report storage config on file type

### DIFF
--- a/src/app/gateway/states/gateway-configuration/components/basic/storage/gateway-storage-configuration.component.html
+++ b/src/app/gateway/states/gateway-configuration/components/basic/storage/gateway-storage-configuration.component.html
@@ -69,6 +69,7 @@
             <mat-error *ngIf="storageFormGroup.get('data_folder_path').hasError('pattern')">
               {{ 'gateway.storage-data-folder-path-pattern' | translate }}
             </mat-error>
+            <mat-hint></mat-hint>
             <mat-icon class="mat-form-field-infix pointer-event suffix-icon" aria-hidden="false"
                       aria-label="help-icon"
                       matSuffix style="cursor:pointer;"

--- a/src/app/gateway/states/gateway-configuration/components/basic/storage/gateway-storage-configuration.component.html
+++ b/src/app/gateway/states/gateway-configuration/components/basic/storage/gateway-storage-configuration.component.html
@@ -59,8 +59,8 @@
         </mat-form-field>
       </section>
       <section *ngSwitchCase="StorageTypes.FILE">
-        <div class="tb-form-row no-border no-padding tb-standard-fields column-xs mb-2">
-          <mat-form-field appearance="outline" class="flex">
+        <div class="tb-form-row no-border no-padding tb-standard-fields column-xs align-start mb-2">
+          <mat-form-field appearance="outline" class="flex" subscriptSizing="dynamic">
             <mat-label translate>gateway.storage-data-folder-path</mat-label>
             <input matInput formControlName="data_folder_path"/>
             <mat-error *ngIf="storageFormGroup.get('data_folder_path').hasError('required')">


### PR DESCRIPTION
Before:
<img width="821" height="599" alt="Знімок екрана 2026-01-21 о 15 32 07" src="https://github.com/user-attachments/assets/26640a74-1ca6-4a86-a6cb-2af6fde1e74f" />

After:
<img width="817" height="594" alt="Знімок екрана 2026-01-21 о 15 30 58" src="https://github.com/user-attachments/assets/da4f4272-29b8-4d9d-b222-a82eaa61df85" />
